### PR TITLE
test: cover unlock-modal, settings tab, api client for v0.1.5

### DIFF
--- a/src/__tests__/settings.test.ts
+++ b/src/__tests__/settings.test.ts
@@ -1,0 +1,372 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mock `obsidian` ────────────────────────────────
+// SilentStoneSyncSettingTab extends PluginSettingTab and uses the Setting
+// builder + Notice. We hand-roll the minimum surface it touches. The tab
+// renders 9 Setting rows across 5 widget types: addText, addToggle,
+// addSlider, addDropdown, addButton. Each captures its change handler so
+// tests can drive the "Test connection" button and assert saveSettings is
+// called on value changes.
+const { MockPluginSettingTab, MockSetting, MockNotice, lastSettings } = vi.hoisted(() => {
+	type FakeEl = {
+		textContent: string;
+		children: FakeEl[];
+		cls: string[];
+		createEl: (tag: string, opts?: { text?: string; cls?: string }) => FakeEl;
+		empty: () => void;
+	};
+
+	function createFakeEl(): FakeEl {
+		const el: FakeEl = {
+			textContent: '',
+			children: [],
+			cls: [],
+			createEl: (_tag, opts) => {
+				const child = createFakeEl();
+				if (opts?.text) child.textContent = opts.text;
+				if (opts?.cls) {
+					for (const c of opts.cls.split(/\s+/)) child.cls.push(c);
+				}
+				el.children.push(child);
+				return child;
+			},
+			empty: () => {
+				el.children = [];
+				el.textContent = '';
+			},
+		};
+		return el;
+	}
+
+	type Captured = {
+		name: string;
+		textOnChange?: (v: string) => void;
+		toggleOnChange?: (v: boolean) => void;
+		sliderOnChange?: (v: number) => void;
+		dropdownOnChange?: (v: string) => void;
+		buttonOnClick?: () => void | Promise<void>;
+	};
+
+	const allSettings: Captured[] = [];
+
+	class MockPluginSettingTab {
+		app: unknown;
+		plugin: unknown;
+		containerEl: FakeEl;
+
+		constructor(app: unknown, plugin: unknown) {
+			this.app = app;
+			this.plugin = plugin;
+			this.containerEl = createFakeEl();
+		}
+	}
+
+	class MockSetting {
+		private captured: Captured;
+
+		constructor(_parent: unknown) {
+			this.captured = { name: '' };
+			allSettings.push(this.captured);
+		}
+
+		setName(n: string): this {
+			this.captured.name = n;
+			return this;
+		}
+
+		setDesc(_d: string): this {
+			return this;
+		}
+
+		addText(cb: (t: unknown) => void): this {
+			const api = {
+				setPlaceholder: (_p: string) => api,
+				setValue: (_v: string) => api,
+				onChange: (fn: (v: string) => void) => {
+					this.captured.textOnChange = fn;
+					return api;
+				},
+			};
+			cb(api);
+			return this;
+		}
+
+		addToggle(cb: (t: unknown) => void): this {
+			const api = {
+				setValue: (_v: boolean) => api,
+				onChange: (fn: (v: boolean) => void) => {
+					this.captured.toggleOnChange = fn;
+					return api;
+				},
+			};
+			cb(api);
+			return this;
+		}
+
+		addSlider(cb: (s: unknown) => void): this {
+			const api = {
+				setLimits: (_a: number, _b: number, _c: number) => api,
+				setValue: (_v: number) => api,
+				setDynamicTooltip: () => api,
+				onChange: (fn: (v: number) => void) => {
+					this.captured.sliderOnChange = fn;
+					return api;
+				},
+			};
+			cb(api);
+			return this;
+		}
+
+		addDropdown(cb: (d: unknown) => void): this {
+			const api = {
+				addOption: (_value: string, _label: string) => api,
+				setValue: (_v: string) => api,
+				onChange: (fn: (v: string) => void) => {
+					this.captured.dropdownOnChange = fn;
+					return api;
+				},
+			};
+			cb(api);
+			return this;
+		}
+
+		addButton(cb: (b: unknown) => void): this {
+			const api = {
+				setButtonText: (_t: string) => api,
+				setCta: () => api,
+				onClick: (fn: () => void | Promise<void>) => {
+					this.captured.buttonOnClick = fn;
+					return api;
+				},
+			};
+			cb(api);
+			return this;
+		}
+	}
+
+	const MockNotice = vi.fn();
+
+	function lastSettings(): Captured[] {
+		return allSettings;
+	}
+
+	return { MockPluginSettingTab, MockSetting, MockNotice, lastSettings };
+});
+
+vi.mock('obsidian', () => ({
+	App: class {},
+	PluginSettingTab: MockPluginSettingTab,
+	Setting: MockSetting,
+	Notice: MockNotice,
+}));
+
+// Mock SilentStoneClient so we can control health() / me() responses.
+const { mockHealth, mockMe } = vi.hoisted(() => ({
+	mockHealth: vi.fn(),
+	mockMe: vi.fn(),
+}));
+
+vi.mock('../api/client', () => ({
+	SilentStoneClient: class {
+		health = mockHealth;
+		me = mockMe;
+		constructor(_serverUrl: string, _token: string) {}
+	},
+}));
+
+import { SilentStoneSyncSettingTab } from '../settings';
+
+// ── Test helpers ───────────────────────────────────
+type VaultResult =
+	| { kind: 'connected'; tier: string; usedBytes: number }
+	| { kind: 'unauthorized' }
+	| { kind: 'error'; message: string }
+	| { kind: 'not-configured' };
+
+type FakePlugin = {
+	settings: {
+		serverUrl: string;
+		nickname: string;
+		authToken: string;
+		folderId: string;
+		autoSync: boolean;
+		syncInterval: number;
+		syncOnStartup: boolean;
+		conflictStrategy: 'ask' | 'keep-local' | 'keep-server' | 'keep-both';
+		debugLogging: boolean;
+	};
+	saveSettings: ReturnType<typeof vi.fn>;
+	checkVaultConnection: ReturnType<typeof vi.fn<() => Promise<VaultResult>>>;
+};
+
+function makePlugin(overrides: Partial<FakePlugin> = {}): FakePlugin {
+	return {
+		settings: {
+			serverUrl: 'https://silentstone.one',
+			nickname: 'tester',
+			authToken: '',
+			folderId: 'my-vault',
+			autoSync: false,
+			syncInterval: 5,
+			syncOnStartup: false,
+			conflictStrategy: 'ask',
+			debugLogging: false,
+		},
+		saveSettings: vi.fn().mockResolvedValue(undefined),
+		checkVaultConnection: vi.fn().mockResolvedValue({ kind: 'not-configured' }),
+		...overrides,
+	};
+}
+
+function openTab(plugin: FakePlugin): SilentStoneSyncSettingTab {
+	const tab = new SilentStoneSyncSettingTab({} as never, plugin as never);
+	tab.display();
+	return tab;
+}
+
+function findByName(name: string) {
+	return lastSettings().find((s) => s.name === name);
+}
+
+beforeEach(() => {
+	lastSettings().length = 0;
+	vi.clearAllMocks();
+});
+
+// ── Smoke: display builds all expected rows ────────
+describe('SilentStoneSyncSettingTab — display()', () => {
+	it('creates all 9 Setting rows without throwing', () => {
+		const plugin = makePlugin();
+		openTab(plugin);
+
+		const names = lastSettings().map((s) => s.name);
+		expect(names).toEqual([
+			'Server URL',
+			'Nickname',
+			'Test connection',
+			'Folder ID',
+			'Auto-sync',
+			'Sync interval',
+			'Sync on startup',
+			'Conflict resolution',
+			'Debug logging',
+		]);
+	});
+
+	it('persists via plugin.saveSettings when a text field changes', async () => {
+		const plugin = makePlugin();
+		openTab(plugin);
+
+		const serverUrlRow = findByName('Server URL');
+		expect(serverUrlRow?.textOnChange).toBeDefined();
+		await serverUrlRow?.textOnChange?.('https://new.example.com');
+
+		expect(plugin.saveSettings).toHaveBeenCalledOnce();
+		expect(plugin.settings.serverUrl).toBe('https://new.example.com');
+	});
+
+	it('persists via plugin.saveSettings when auto-sync toggles', async () => {
+		const plugin = makePlugin();
+		openTab(plugin);
+
+		const toggleRow = findByName('Auto-sync');
+		await toggleRow?.toggleOnChange?.(true);
+
+		expect(plugin.saveSettings).toHaveBeenCalledOnce();
+		expect(plugin.settings.autoSync).toBe(true);
+	});
+});
+
+// ── Test-connection button: four-branch handler ────
+describe('SilentStoneSyncSettingTab — Test connection handler', () => {
+	it('shows "Cannot reach server" when health check fails', async () => {
+		const plugin = makePlugin();
+		mockHealth.mockResolvedValueOnce(false);
+		openTab(plugin);
+
+		await findByName('Test connection')?.buttonOnClick?.();
+
+		expect(MockNotice).toHaveBeenCalledWith('Cannot reach server. Check the URL.');
+		expect(plugin.checkVaultConnection).not.toHaveBeenCalled();
+	});
+
+	it('shows vault-connected notice with tier and MB used', async () => {
+		const plugin = makePlugin({
+			checkVaultConnection: vi.fn().mockResolvedValue({
+				kind: 'connected',
+				tier: 'pro',
+				usedBytes: 2 * 1024 * 1024 + 500 * 1024,
+			}),
+		});
+		mockHealth.mockResolvedValueOnce(true);
+		openTab(plugin);
+
+		await findByName('Test connection')?.buttonOnClick?.();
+
+		expect(MockNotice).toHaveBeenCalledWith(
+			expect.stringMatching(/Vault connected \(tier: pro, 2\.5 MB used\)/),
+		);
+	});
+
+	it('shows "Vault token expired" notice on unauthorized', async () => {
+		const plugin = makePlugin({
+			checkVaultConnection: vi.fn().mockResolvedValue({ kind: 'unauthorized' }),
+		});
+		mockHealth.mockResolvedValueOnce(true);
+		openTab(plugin);
+
+		await findByName('Test connection')?.buttonOnClick?.();
+
+		expect(MockNotice).toHaveBeenCalledWith(
+			expect.stringContaining('Vault token expired or revoked'),
+		);
+	});
+
+	it('shows vault error message on error kind', async () => {
+		const plugin = makePlugin({
+			checkVaultConnection: vi.fn().mockResolvedValue({
+				kind: 'error',
+				message: 'server 500',
+			}),
+		});
+		mockHealth.mockResolvedValueOnce(true);
+		openTab(plugin);
+
+		await findByName('Test connection')?.buttonOnClick?.();
+
+		expect(MockNotice).toHaveBeenCalledWith('Vault check failed: server 500');
+	});
+
+	it('falls through to Syncthing me() when vault not-configured and authToken present', async () => {
+		const plugin = makePlugin({
+			settings: {
+				...makePlugin().settings,
+				authToken: 'syncthing-token',
+			},
+			checkVaultConnection: vi.fn().mockResolvedValue({ kind: 'not-configured' }),
+		});
+		mockHealth.mockResolvedValueOnce(true);
+		mockMe.mockResolvedValueOnce({ nickname: 'alice', role: 'admin' });
+		openTab(plugin);
+
+		await findByName('Test connection')?.buttonOnClick?.();
+
+		expect(mockMe).toHaveBeenCalledOnce();
+		expect(MockNotice).toHaveBeenCalledWith('Connected as alice (admin)');
+	});
+
+	it('shows setup hint when vault not-configured and no authToken', async () => {
+		const plugin = makePlugin({
+			checkVaultConnection: vi.fn().mockResolvedValue({ kind: 'not-configured' }),
+		});
+		mockHealth.mockResolvedValueOnce(true);
+		openTab(plugin);
+
+		await findByName('Test connection')?.buttonOnClick?.();
+
+		expect(mockMe).not.toHaveBeenCalled();
+		expect(MockNotice).toHaveBeenCalledWith(
+			expect.stringContaining('Run "Vault: first-time setup"'),
+		);
+	});
+});

--- a/src/api/__tests__/client.test.ts
+++ b/src/api/__tests__/client.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mock `obsidian` ────────────────────────────────
+// SilentStoneClient imports `requestUrl` from 'obsidian', provided by
+// Obsidian at runtime and never bundled. Mock it so tests can control
+// responses and inspect call arguments. Mirrors vault-client.test.ts.
+const { mockRequestUrl } = vi.hoisted(() => ({
+	mockRequestUrl: vi.fn(),
+}));
+
+vi.mock('obsidian', () => ({
+	requestUrl: mockRequestUrl,
+}));
+
+import { SilentStoneClient } from '../client';
+import type { FileEntry, FolderInfo, MeResponse, TokenResponse } from '../types';
+
+// ── Helpers ────────────────────────────────────────
+const BASE_URL = 'https://sync.example.com';
+const TOKEN = 'syncthing-bearer-token-abc';
+
+function okJson<T>(body: T, status = 200) {
+	return { status, json: body, headers: {}, arrayBuffer: new ArrayBuffer(0) };
+}
+
+function lastCall(): Record<string, unknown> {
+	const calls = mockRequestUrl.mock.calls;
+	expect(calls.length).toBeGreaterThan(0);
+	return calls[calls.length - 1][0] as Record<string, unknown>;
+}
+
+beforeEach(() => {
+	mockRequestUrl.mockReset();
+});
+
+// ── Construction & token lifecycle ────────────────
+describe('SilentStoneClient — construction', () => {
+	it('strips a trailing slash from serverUrl', async () => {
+		const client = new SilentStoneClient(`${BASE_URL}/`, TOKEN);
+		mockRequestUrl.mockResolvedValueOnce(okJson<MeResponse>({
+			nickname: 'tester',
+			role: 'admin',
+		}));
+
+		await client.me();
+
+		expect(lastCall().url).toBe(`${BASE_URL}/api/auth/me`);
+	});
+
+	it('leaves a slashless serverUrl untouched', async () => {
+		const client = new SilentStoneClient(BASE_URL, TOKEN);
+		mockRequestUrl.mockResolvedValueOnce(okJson<MeResponse>({
+			nickname: 'tester',
+			role: 'admin',
+		}));
+
+		await client.me();
+
+		expect(lastCall().url).toBe(`${BASE_URL}/api/auth/me`);
+	});
+
+	it('setToken replaces the Bearer token used on subsequent requests', async () => {
+		const client = new SilentStoneClient(BASE_URL, 'stale');
+		client.setToken('fresh');
+		mockRequestUrl.mockResolvedValueOnce(okJson<MeResponse>({
+			nickname: 'tester',
+			role: 'admin',
+		}));
+
+		await client.me();
+
+		const headers = lastCall().headers as Record<string, string>;
+		expect(headers.Authorization).toBe('Bearer fresh');
+	});
+});
+
+// ── Auth endpoints ─────────────────────────────────
+describe('SilentStoneClient — login', () => {
+	it('POSTs to /api/auth/token with JSON body and no Bearer header', async () => {
+		const client = new SilentStoneClient(BASE_URL, '');
+		mockRequestUrl.mockResolvedValueOnce(okJson<TokenResponse>({
+			ok: true,
+			token: 'new-token-xyz',
+		}));
+
+		const result = await client.login('alice', 's3cret');
+
+		const call = lastCall();
+		expect(call.url).toBe(`${BASE_URL}/api/auth/token`);
+		expect(call.method).toBe('POST');
+		expect(call.body).toBe(JSON.stringify({ nickname: 'alice', password: 's3cret' }));
+		const headers = call.headers as Record<string, string>;
+		expect(headers['Content-Type']).toBe('application/json');
+		expect(headers.Authorization).toBeUndefined();
+		expect(result.token).toBe('new-token-xyz');
+	});
+});
+
+describe('SilentStoneClient — me', () => {
+	it('GETs /api/auth/me with Bearer + JSON Content-Type', async () => {
+		const client = new SilentStoneClient(BASE_URL, TOKEN);
+		mockRequestUrl.mockResolvedValueOnce(okJson<MeResponse>({
+			nickname: 'bob',
+			role: 'member',
+		}));
+
+		const me = await client.me();
+
+		const call = lastCall();
+		expect(call.method).toBe('GET');
+		const headers = call.headers as Record<string, string>;
+		expect(headers.Authorization).toBe(`Bearer ${TOKEN}`);
+		expect(headers['Content-Type']).toBe('application/json');
+		expect(me.nickname).toBe('bob');
+		expect(me.role).toBe('member');
+	});
+
+	it('propagates a requestUrl rejection (401 etc.) to the caller', async () => {
+		const client = new SilentStoneClient(BASE_URL, 'bad-token');
+		const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+		mockRequestUrl.mockRejectedValueOnce(err);
+
+		await expect(client.me()).rejects.toMatchObject({ status: 401 });
+	});
+});
+
+// ── Folder endpoints ───────────────────────────────
+describe('SilentStoneClient — folder operations', () => {
+	it('listFolders GETs /api/folders with Bearer', async () => {
+		const client = new SilentStoneClient(BASE_URL, TOKEN);
+		const folders: FolderInfo[] = [
+			{
+				id: 'vault-a',
+				label: 'Vault A',
+				path: '/vault-a',
+				type: 'sendreceive',
+				encrypted: false,
+				devices: [],
+			},
+		];
+		mockRequestUrl.mockResolvedValueOnce(okJson(folders));
+
+		const result = await client.listFolders();
+
+		expect(lastCall().url).toBe(`${BASE_URL}/api/folders`);
+		expect(result).toEqual(folders);
+	});
+
+	it('listFiles appends URL-encoded path query when provided', async () => {
+		const client = new SilentStoneClient(BASE_URL, TOKEN);
+		mockRequestUrl.mockResolvedValueOnce(okJson<FileEntry[]>([]));
+
+		await client.listFiles('folder-1', 'notes/subfolder with space');
+
+		expect(lastCall().url).toBe(
+			`${BASE_URL}/api/folders/folder-1/files?path=${encodeURIComponent('notes/subfolder with space')}`,
+		);
+	});
+
+	it('listFiles omits the query string when path is empty', async () => {
+		const client = new SilentStoneClient(BASE_URL, TOKEN);
+		mockRequestUrl.mockResolvedValueOnce(okJson<FileEntry[]>([]));
+
+		await client.listFiles('folder-1');
+
+		expect(lastCall().url).toBe(`${BASE_URL}/api/folders/folder-1/files`);
+	});
+});
+
+// ── Health check ───────────────────────────────────
+describe('SilentStoneClient — health', () => {
+	it('returns true when server responds 200', async () => {
+		const client = new SilentStoneClient(BASE_URL, TOKEN);
+		mockRequestUrl.mockResolvedValueOnce(okJson({ ok: true }, 200));
+
+		expect(await client.health()).toBe(true);
+	});
+
+	it('returns false when server responds non-200', async () => {
+		const client = new SilentStoneClient(BASE_URL, TOKEN);
+		mockRequestUrl.mockResolvedValueOnce(okJson({ ok: false }, 503));
+
+		expect(await client.health()).toBe(false);
+	});
+
+	it('returns false when requestUrl throws (network error)', async () => {
+		const client = new SilentStoneClient(BASE_URL, TOKEN);
+		mockRequestUrl.mockRejectedValueOnce(new Error('connection refused'));
+
+		expect(await client.health()).toBe(false);
+	});
+
+	it('health check omits Authorization header (public endpoint)', async () => {
+		const client = new SilentStoneClient(BASE_URL, TOKEN);
+		mockRequestUrl.mockResolvedValueOnce(okJson({ ok: true }, 200));
+
+		await client.health();
+
+		const call = lastCall();
+		expect(call.headers).toBeUndefined();
+	});
+});

--- a/src/ui/__tests__/unlock-modal.test.ts
+++ b/src/ui/__tests__/unlock-modal.test.ts
@@ -1,0 +1,357 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mock `obsidian` ────────────────────────────────
+// UnlockModal extends Obsidian's Modal and uses the Setting builder. We
+// hand-roll the minimum DOM + widget surface it touches: contentEl with
+// createEl/empty, setText, style object, a chainable Setting class that
+// captures addText/addButton handlers so tests can drive them.
+//
+// Mocks are hoisted via vi.hoisted so vi.mock's factory can reference them.
+const { MockModal, MockSetting, lastSettings } = vi.hoisted(() => {
+	type InputListener = (e: { key: string; preventDefault: () => void }) => void;
+
+	type FakeInputEl = {
+		type: string;
+		value: string;
+		focus: ReturnType<typeof vi.fn>;
+		addEventListener: (evt: string, cb: InputListener) => void;
+		__listeners: Record<string, InputListener[]>;
+	};
+
+	type FakeButtonEl = { disabled: boolean; textContent: string };
+
+	type FakeEl = {
+		tagName: string;
+		textContent: string;
+		children: FakeEl[];
+		cls: string[];
+		style: Record<string, string>;
+		attrs: Record<string, string>;
+		createEl: (tag: string, opts?: { text?: string; cls?: string; attr?: Record<string, string> }) => FakeEl;
+		setText: (t: string) => void;
+		empty: () => void;
+	};
+
+	type TextHandler = {
+		inputEl: FakeInputEl;
+		onChange?: (v: string) => void;
+	};
+
+	type ButtonHandler = {
+		buttonEl: FakeButtonEl;
+		onClick?: () => void | Promise<void>;
+		setButtonTextCalls: string[];
+	};
+
+	type Handlers = {
+		textHandlers: TextHandler[];
+		buttonHandlers: ButtonHandler[];
+	};
+
+	const allSettings: Handlers[] = [];
+
+	function createFakeEl(tag: string): FakeEl {
+		const el: FakeEl = {
+			tagName: tag.toUpperCase(),
+			textContent: '',
+			children: [],
+			cls: [],
+			style: {},
+			attrs: {},
+			createEl: (t, opts) => {
+				const child = createFakeEl(t);
+				if (opts?.text) child.textContent = opts.text;
+				if (opts?.cls) {
+					for (const c of opts.cls.split(/\s+/)) child.cls.push(c);
+				}
+				if (opts?.attr) {
+					for (const [k, v] of Object.entries(opts.attr)) child.attrs[k] = v;
+					if (opts.attr.style) {
+						for (const part of opts.attr.style.split(';')) {
+							const [k, v] = part.split(':').map((s) => s.trim());
+							if (k) child.style[k] = v ?? '';
+						}
+					}
+				}
+				el.children.push(child);
+				return child;
+			},
+			setText: (t) => {
+				el.textContent = t;
+			},
+			empty: () => {
+				el.children = [];
+				el.textContent = '';
+			},
+		};
+		return el;
+	}
+
+	class MockModal {
+		app: unknown;
+		contentEl: FakeEl;
+		close: ReturnType<typeof vi.fn>;
+
+		constructor(app: unknown) {
+			this.app = app;
+			this.contentEl = createFakeEl('div');
+			this.close = vi.fn();
+		}
+
+		open(): void {
+			(this as unknown as { onOpen?: () => void }).onOpen?.();
+		}
+	}
+
+	class MockSetting {
+		private handlers: Handlers;
+
+		constructor(_parent: unknown) {
+			this.handlers = { textHandlers: [], buttonHandlers: [] };
+			allSettings.push(this.handlers);
+		}
+
+		setName(_name: string): this {
+			return this;
+		}
+
+		setDesc(_desc: string): this {
+			return this;
+		}
+
+		addText(cb: (t: unknown) => void): this {
+			const inputEl: FakeInputEl = {
+				type: 'text',
+				value: '',
+				focus: vi.fn(),
+				__listeners: {},
+				addEventListener: (evt, fn) => {
+					inputEl.__listeners[evt] ||= [];
+					inputEl.__listeners[evt].push(fn);
+				},
+			};
+			const captured: TextHandler = { inputEl };
+			const api = {
+				setPlaceholder: (_p: string) => api,
+				onChange: (fn: (v: string) => void) => {
+					captured.onChange = fn;
+					return api;
+				},
+				inputEl,
+			};
+			cb(api);
+			this.handlers.textHandlers.push(captured);
+			return this;
+		}
+
+		addButton(cb: (b: unknown) => void): this {
+			const buttonEl: FakeButtonEl = { disabled: false, textContent: '' };
+			const captured: ButtonHandler = { buttonEl, setButtonTextCalls: [] };
+			const api = {
+				setButtonText: (t: string) => {
+					captured.setButtonTextCalls.push(t);
+					buttonEl.textContent = t;
+					return api;
+				},
+				setCta: () => api,
+				onClick: (fn: () => void | Promise<void>) => {
+					captured.onClick = fn;
+					return api;
+				},
+				buttonEl,
+			};
+			cb(api);
+			this.handlers.buttonHandlers.push(captured);
+			return this;
+		}
+	}
+
+	function lastSettings(): Handlers[] {
+		return allSettings;
+	}
+
+	return { MockModal, MockSetting, lastSettings };
+});
+
+vi.mock('obsidian', () => ({
+	App: class {},
+	Modal: MockModal,
+	Setting: MockSetting,
+}));
+
+import { UnlockModal } from '../unlock-modal';
+
+// ── Test helpers ───────────────────────────────────
+type FakePlugin = {
+	settings: { serverUrl: string; nickname: string };
+	unlockVaultWithPassword: ReturnType<typeof vi.fn>;
+};
+
+function makeFakePlugin(overrides: Partial<FakePlugin> = {}): FakePlugin {
+	return {
+		settings: {
+			serverUrl: 'https://dev.silentstone.one',
+			nickname: 'tester',
+		},
+		unlockVaultWithPassword: vi.fn().mockResolvedValue(undefined),
+		...overrides,
+	};
+}
+
+type TreeNode = { textContent: string; children: TreeNode[] };
+
+function findByText(el: unknown, needle: string): boolean {
+	const node = el as TreeNode;
+	if ((node.textContent ?? '').includes(needle)) return true;
+	for (const c of node.children ?? []) {
+		if (findByText(c, needle)) return true;
+	}
+	return false;
+}
+
+function openModal(plugin: FakePlugin): UnlockModal {
+	const modal = new UnlockModal({} as never, plugin as never);
+	(modal as unknown as { open: () => void }).open();
+	return modal;
+}
+
+/** Search across all Setting rows for the first text handler and first button. */
+function findHandlers() {
+	const settings = lastSettings();
+	const textHandlers = settings.flatMap((s) => s.textHandlers);
+	const buttonHandlers = settings.flatMap((s) => s.buttonHandlers);
+	return {
+		password: textHandlers[0],
+		submit: buttonHandlers[0],
+	};
+}
+
+async function typeAndSubmit(_modal: UnlockModal, password: string): Promise<void> {
+	const { password: passwordHandler, submit } = findHandlers();
+	if (!passwordHandler || !submit) {
+		throw new Error('modal did not render password input + submit button');
+	}
+
+	passwordHandler.inputEl.value = password;
+	passwordHandler.onChange?.(password);
+	await submit.onClick?.();
+	await Promise.resolve();
+}
+
+beforeEach(() => {
+	// Clear collected settings between tests so lastSettings() returns the
+	// ones from the current modal open, not a stale global list.
+	const all = lastSettings();
+	all.length = 0;
+	vi.clearAllMocks();
+});
+
+// ── Render branches ─────────────────────────────────
+describe('UnlockModal — render', () => {
+	it('renders heading + description + password field + Unlock button when configured', () => {
+		const plugin = makeFakePlugin();
+		const modal = openModal(plugin);
+
+		expect(findByText(modal.contentEl, 'Unlock Silent Stone vault')).toBe(true);
+		expect(findByText(modal.contentEl, 'master key stays in memory only')).toBe(true);
+
+		const { password, submit } = findHandlers();
+		expect(password?.inputEl.type).toBe('password');
+		expect(submit?.buttonEl.textContent).toBe('Unlock');
+	});
+
+	it('shows warning and skips form when serverUrl is missing', () => {
+		const plugin = makeFakePlugin({
+			settings: { serverUrl: '', nickname: 'tester' },
+		});
+		const modal = openModal(plugin);
+
+		expect(findByText(modal.contentEl, 'Server URL and nickname must be set')).toBe(true);
+		// No Setting rows rendered
+		expect(lastSettings()).toHaveLength(0);
+	});
+
+	it('shows warning and skips form when nickname is missing', () => {
+		const plugin = makeFakePlugin({
+			settings: { serverUrl: 'https://x', nickname: '' },
+		});
+		const modal = openModal(plugin);
+
+		expect(findByText(modal.contentEl, 'Server URL and nickname must be set')).toBe(true);
+		expect(lastSettings()).toHaveLength(0);
+	});
+});
+
+// ── Submit behavior ─────────────────────────────────
+describe('UnlockModal — submit', () => {
+	it('shows "Password required." error when submitted with empty password', async () => {
+		const plugin = makeFakePlugin();
+		const modal = openModal(plugin);
+
+		await typeAndSubmit(modal, '');
+
+		expect(plugin.unlockVaultWithPassword).not.toHaveBeenCalled();
+		expect(findByText(modal.contentEl, 'Password required.')).toBe(true);
+	});
+
+	it('on success: calls plugin.unlockVaultWithPassword and closes modal', async () => {
+		const plugin = makeFakePlugin();
+		const modal = openModal(plugin);
+
+		await typeAndSubmit(modal, 'correct-horse-battery-staple');
+
+		expect(plugin.unlockVaultWithPassword).toHaveBeenCalledWith('correct-horse-battery-staple');
+		expect(modal.close).toHaveBeenCalledOnce();
+	});
+
+	it('maps decryption errors to a friendly "Wrong password" message', async () => {
+		const plugin = makeFakePlugin({
+			unlockVaultWithPassword: vi
+				.fn()
+				.mockRejectedValue(new Error('The operation failed for an operation-specific reason')),
+		});
+		const modal = openModal(plugin);
+
+		await typeAndSubmit(modal, 'wrong-password');
+
+		expect(modal.close).not.toHaveBeenCalled();
+		expect(findByText(modal.contentEl, 'Wrong password or corrupted vault keys')).toBe(true);
+	});
+
+	it('passes through "vault keys not set up" errors unchanged', async () => {
+		const plugin = makeFakePlugin({
+			unlockVaultWithPassword: vi
+				.fn()
+				.mockRejectedValue(new Error('Vault keys not set up. Run first-time setup.')),
+		});
+		const modal = openModal(plugin);
+
+		await typeAndSubmit(modal, 'any-password');
+
+		expect(findByText(modal.contentEl, 'Vault keys not set up')).toBe(true);
+	});
+
+	it('wraps unknown errors with "Unlock failed: ..." prefix', async () => {
+		const plugin = makeFakePlugin({
+			unlockVaultWithPassword: vi.fn().mockRejectedValue(new Error('Network offline')),
+		});
+		const modal = openModal(plugin);
+
+		await typeAndSubmit(modal, 'any-password');
+
+		expect(findByText(modal.contentEl, 'Unlock failed: Network offline')).toBe(true);
+	});
+
+	it('clears the password field after a failed unlock', async () => {
+		const plugin = makeFakePlugin({
+			unlockVaultWithPassword: vi.fn().mockRejectedValue(new Error('decrypt failed')),
+		});
+		const modal = openModal(plugin);
+		const { password: passwordHandler } = findHandlers();
+		if (!passwordHandler) throw new Error('no password handler');
+
+		await typeAndSubmit(modal, 'wrong-password');
+
+		expect(passwordHandler.inputEl.value).toBe('');
+	});
+});


### PR DESCRIPTION
## Summary

Fills three test-coverage gaps for the `plugin-v0.1.5 — Foundational Stabilization` milestone. Pragmatic depth — happy path plus 1-2 error cases per concern. Mirrors the existing DOM mock pattern in \`setup-modal.test.ts\` and the \`requestUrl\` mock pattern in \`vault-client.test.ts\`.

## Coverage delta

**Before:** 132 tests / 7 files. **After:** 163 tests / 10 files. **Added: 31 tests / 3 files.**

| New file | Tests | What it covers |
|----------|-------|----------------|
| \`src/ui/__tests__/unlock-modal.test.ts\` | 9 | Password gate that protects the sync engine. Render branches, empty-password validation, successful unlock, friendlyError mapping for decrypt failures, pass-through for known error categories, password field clearing after failure. |
| \`src/__tests__/settings.test.ts\` | 9 | Settings tab (9 Setting rows across 5 widget types). Covers saveSettings plumbing on text + toggle changes and the four-branch Test connection handler (health fail / vault connected / unauthorized / error / not-configured with Syncthing me() fallthrough). |
| \`src/api/__tests__/client.test.ts\` | 13 | \`SilentStoneClient\` (Syncthing track). URL normalization, setToken lifecycle, login/me/listFolders/listFiles/health including 401 propagation, path query URL-encoding, and health omitting the auth header (public endpoint). |

## Discovery notes

- **Issues #12 and #13 are NOT covered here** — their source files (\`status-bar.ts\`, \`sync-modal.ts\`) are placeholder stubs. Tests will naturally queue up once the real implementations land in #3 and #2 respectively. Blocker comments posted on both by github-manager during this mission.
- **Issue #15's framing was slightly off** — \`src/settings.ts\` turned out to be \`SilentStoneSyncSettingTab\` (a UI tab), not a persistence module. Settings load/save logic actually lives in \`main.ts\`. Test scope adjusted to cover the actual logic (Test connection handler branching) rather than chase a nonexistent surface.

## Verification

\`\`\`
npm run lint       # 0 errors, 3 pre-existing warnings (no-explicit-any in setup-modal.test.ts)
npm run typecheck  # Clean
npm test           # 163/163 passing in 10 files
npm run build      # Clean
\`\`\`

## Test plan

- [ ] CI gate (added in #18) runs green on this PR
- [ ] Merge, then issues #14, #15, #16 auto-close
- [ ] No regression in 132 pre-existing tests

Closes #14. Closes #15. Closes #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)