### PR TITLE
feat(plugin): add auto-popup login modal (#5)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import type { WrappedKey } from './crypto/types';
 import { ManifestManager } from './sync/manifest';
 import { FileWatcher } from './sync/watcher';
 import { SyncEngine } from './sync/engine';
+import { LoginModal } from './ui/login-modal';
 import { SetupModal } from './ui/setup-modal';
 import { UnlockModal } from './ui/unlock-modal';
 
@@ -54,6 +55,12 @@ export default class SilentStoneSyncPlugin extends Plugin {
       id: 'check-connection',
       name: 'Check server connection',
       callback: () => this.checkConnection(),
+    });
+
+    this.addCommand({
+      id: 'vault-login',
+      name: 'Vault: log in',
+      callback: () => new LoginModal(this.app, this).open(),
     });
 
     this.addCommand({
@@ -106,6 +113,13 @@ export default class SilentStoneSyncPlugin extends Plugin {
         this.settings.serverUrl,
         this.settings.vaultAuthToken,
       );
+    } else if (!this.settings.vaultAuthToken) {
+      // First-run UX: no Bearer token persisted → auto-popup login modal so
+      // the user isn't left hunting through the command palette. Deferred via
+      // setTimeout so the workspace finishes loading before the modal opens.
+      this.app.workspace.onLayoutReady(() => {
+        new LoginModal(this.app, this).open();
+      });
     }
 
     // TODO: Register vault file watchers for auto-sync

--- a/src/ui/__tests__/login-modal.test.ts
+++ b/src/ui/__tests__/login-modal.test.ts
@@ -1,0 +1,476 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mock `obsidian` ────────────────────────────────
+// Mirrors the mock infrastructure in unlock-modal.test.ts. We hand-roll the
+// minimum DOM + widget surface LoginModal touches: contentEl with createEl/
+// empty, setText, style object, a chainable Setting class that captures
+// addText/addButton handlers so tests can drive them.
+//
+// Mocks are hoisted via vi.hoisted so vi.mock's factory can reference them.
+const { MockModal, MockSetting, lastSettings } = vi.hoisted(() => {
+  type InputListener = (e: { key: string; preventDefault: () => void }) => void;
+
+  type FakeInputEl = {
+    type: string;
+    value: string;
+    focus: ReturnType<typeof vi.fn>;
+    addEventListener: (evt: string, cb: InputListener) => void;
+    __listeners: Record<string, InputListener[]>;
+  };
+
+  type FakeButtonEl = { disabled: boolean; textContent: string };
+
+  type ClickListener = (e: { preventDefault: () => void }) => void;
+
+  type FakeEl = {
+    tagName: string;
+    textContent: string;
+    children: FakeEl[];
+    cls: string[];
+    style: Record<string, string>;
+    attrs: Record<string, string>;
+    __clickListeners: ClickListener[];
+    createEl: (
+      tag: string,
+      opts?: { text?: string; cls?: string; attr?: Record<string, string> },
+    ) => FakeEl;
+    setText: (t: string) => void;
+    empty: () => void;
+    addEventListener: (evt: string, cb: ClickListener) => void;
+  };
+
+  type TextHandler = {
+    inputEl: FakeInputEl;
+    onChange?: (v: string) => void;
+    placeholder?: string;
+    initialValue?: string;
+  };
+
+  type ButtonHandler = {
+    buttonEl: FakeButtonEl;
+    onClick?: () => void | Promise<void>;
+    setButtonTextCalls: string[];
+  };
+
+  type Handlers = {
+    textHandlers: TextHandler[];
+    buttonHandlers: ButtonHandler[];
+  };
+
+  const allSettings: Handlers[] = [];
+
+  function createFakeEl(tag: string): FakeEl {
+    const el: FakeEl = {
+      tagName: tag.toUpperCase(),
+      textContent: '',
+      children: [],
+      cls: [],
+      style: {},
+      attrs: {},
+      __clickListeners: [],
+      createEl: (t, opts) => {
+        const child = createFakeEl(t);
+        if (opts?.text) child.textContent = opts.text;
+        if (opts?.cls) {
+          for (const c of opts.cls.split(/\s+/)) child.cls.push(c);
+        }
+        if (opts?.attr) {
+          for (const [k, v] of Object.entries(opts.attr)) child.attrs[k] = v;
+          if (opts.attr.style) {
+            for (const part of opts.attr.style.split(';')) {
+              const [k, v] = part.split(':').map((s) => s.trim());
+              if (k) child.style[k] = v ?? '';
+            }
+          }
+        }
+        el.children.push(child);
+        return child;
+      },
+      setText: (t) => {
+        el.textContent = t;
+      },
+      empty: () => {
+        el.children = [];
+        el.textContent = '';
+      },
+      addEventListener: (evt, cb) => {
+        if (evt === 'click') el.__clickListeners.push(cb);
+      },
+    };
+    return el;
+  }
+
+  class MockModal {
+    app: unknown;
+    contentEl: FakeEl;
+    close: ReturnType<typeof vi.fn>;
+
+    constructor(app: unknown) {
+      this.app = app;
+      this.contentEl = createFakeEl('div');
+      this.close = vi.fn();
+    }
+
+    open(): void {
+      (this as unknown as { onOpen?: () => void }).onOpen?.();
+    }
+  }
+
+  class MockSetting {
+    private handlers: Handlers;
+
+    constructor(_parent: unknown) {
+      this.handlers = { textHandlers: [], buttonHandlers: [] };
+      allSettings.push(this.handlers);
+    }
+
+    setName(_name: string): this {
+      return this;
+    }
+
+    setDesc(_desc: string): this {
+      return this;
+    }
+
+    addText(cb: (t: unknown) => void): this {
+      const inputEl: FakeInputEl = {
+        type: 'text',
+        value: '',
+        focus: vi.fn(),
+        __listeners: {},
+        addEventListener: (evt, fn) => {
+          inputEl.__listeners[evt] ||= [];
+          inputEl.__listeners[evt].push(fn);
+        },
+      };
+      const captured: TextHandler = { inputEl };
+      const api = {
+        setPlaceholder: (p: string) => {
+          captured.placeholder = p;
+          return api;
+        },
+        setValue: (v: string) => {
+          captured.initialValue = v;
+          inputEl.value = v;
+          return api;
+        },
+        onChange: (fn: (v: string) => void) => {
+          captured.onChange = fn;
+          return api;
+        },
+        inputEl,
+      };
+      cb(api);
+      this.handlers.textHandlers.push(captured);
+      return this;
+    }
+
+    addButton(cb: (b: unknown) => void): this {
+      const buttonEl: FakeButtonEl = { disabled: false, textContent: '' };
+      const captured: ButtonHandler = { buttonEl, setButtonTextCalls: [] };
+      const api = {
+        setButtonText: (t: string) => {
+          captured.setButtonTextCalls.push(t);
+          buttonEl.textContent = t;
+          return api;
+        },
+        setCta: () => api,
+        onClick: (fn: () => void | Promise<void>) => {
+          captured.onClick = fn;
+          return api;
+        },
+        buttonEl,
+      };
+      cb(api);
+      this.handlers.buttonHandlers.push(captured);
+      return this;
+    }
+  }
+
+  function lastSettings(): Handlers[] {
+    return allSettings;
+  }
+
+  return { MockModal, MockSetting, lastSettings };
+});
+
+vi.mock('obsidian', () => ({
+  App: class {},
+  Modal: MockModal,
+  Setting: MockSetting,
+}));
+
+import { LoginModal } from '../login-modal';
+
+// ── Test helpers ───────────────────────────────────
+type FakePlugin = {
+  settings: { serverUrl: string; nickname: string; vaultAuthToken: string };
+  saveSettings: ReturnType<typeof vi.fn>;
+  unlockVaultWithPassword: ReturnType<typeof vi.fn>;
+};
+
+function makeFakePlugin(overrides: Partial<FakePlugin['settings']> = {}): FakePlugin {
+  return {
+    settings: {
+      serverUrl: 'https://dev.silentstone.one',
+      nickname: '',
+      vaultAuthToken: '',
+      ...overrides,
+    },
+    saveSettings: vi.fn().mockResolvedValue(undefined),
+    unlockVaultWithPassword: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+type TreeNode = { textContent: string; children: TreeNode[] };
+
+function findByText(el: unknown, needle: string): boolean {
+  const node = el as TreeNode;
+  if ((node.textContent ?? '').includes(needle)) return true;
+  for (const c of node.children ?? []) {
+    if (findByText(c, needle)) return true;
+  }
+  return false;
+}
+
+function openModal(plugin: FakePlugin): LoginModal {
+  const modal = new LoginModal({} as never, plugin as never);
+  (modal as unknown as { open: () => void }).open();
+  return modal;
+}
+
+/** First text input = nickname, second = password. First button = Log in, second = Cancel. */
+function findHandlers() {
+  const settings = lastSettings();
+  const textHandlers = settings.flatMap((s) => s.textHandlers);
+  const buttonHandlers = settings.flatMap((s) => s.buttonHandlers);
+  return {
+    nickname: textHandlers[0],
+    password: textHandlers[1],
+    login: buttonHandlers[0],
+    cancel: buttonHandlers[1],
+  };
+}
+
+async function fillAndSubmit(
+  _modal: LoginModal,
+  nickname: string,
+  password: string,
+): Promise<void> {
+  const { nickname: n, password: p, login } = findHandlers();
+  if (!n || !p || !login) throw new Error('modal did not render all expected controls');
+
+  n.inputEl.value = nickname;
+  n.onChange?.(nickname);
+
+  p.inputEl.value = password;
+  p.onChange?.(password);
+
+  await login.onClick?.();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  const all = lastSettings();
+  all.length = 0;
+  vi.clearAllMocks();
+});
+
+// ── Render branches ─────────────────────────────────
+describe('LoginModal — render', () => {
+  it('renders heading, description, nickname field, password field, Log in + Cancel buttons', () => {
+    const plugin = makeFakePlugin();
+    const modal = openModal(plugin);
+
+    expect(findByText(modal.contentEl, 'Sign in to Silent Stone')).toBe(true);
+    expect(findByText(modal.contentEl, 'Log in to your account')).toBe(true);
+
+    const { nickname, password, login, cancel } = findHandlers();
+    expect(nickname?.placeholder).toBe('your nickname');
+    expect(password?.inputEl.type).toBe('password');
+    expect(login?.buttonEl.textContent).toBe('Log in');
+    expect(cancel?.buttonEl.textContent).toBe('Cancel');
+  });
+
+  it('renders "Create account" link pointing to /signup', () => {
+    const plugin = makeFakePlugin();
+    const modal = openModal(plugin);
+
+    expect(findByText(modal.contentEl, "Don't have an account?")).toBe(true);
+    expect(findByText(modal.contentEl, 'Create one')).toBe(true);
+  });
+
+  it('pre-fills nickname from settings when present', () => {
+    const plugin = makeFakePlugin({ nickname: 'daisy' });
+    openModal(plugin);
+
+    const { nickname } = findHandlers();
+    expect(nickname?.initialValue).toBe('daisy');
+  });
+
+  it('leaves nickname blank when settings.nickname is empty', () => {
+    const plugin = makeFakePlugin({ nickname: '' });
+    openModal(plugin);
+
+    const { nickname } = findHandlers();
+    expect(nickname?.initialValue ?? '').toBe('');
+  });
+
+  it('Cancel button closes the modal without calling unlockVaultWithPassword', () => {
+    const plugin = makeFakePlugin();
+    const modal = openModal(plugin);
+
+    const { cancel } = findHandlers();
+    cancel?.onClick?.();
+
+    expect(modal.close).toHaveBeenCalledOnce();
+    expect(plugin.unlockVaultWithPassword).not.toHaveBeenCalled();
+  });
+});
+
+// ── Validation ──────────────────────────────────────
+describe('LoginModal — validation', () => {
+  it('shows "Nickname required." when submitted with empty nickname', async () => {
+    const plugin = makeFakePlugin();
+    const modal = openModal(plugin);
+
+    await fillAndSubmit(modal, '', 'some-password');
+
+    expect(plugin.unlockVaultWithPassword).not.toHaveBeenCalled();
+    expect(findByText(modal.contentEl, 'Nickname required.')).toBe(true);
+  });
+
+  it('shows "Password required." when submitted with empty password', async () => {
+    const plugin = makeFakePlugin();
+    const modal = openModal(plugin);
+
+    await fillAndSubmit(modal, 'daisy', '');
+
+    expect(plugin.unlockVaultWithPassword).not.toHaveBeenCalled();
+    expect(findByText(modal.contentEl, 'Password required.')).toBe(true);
+  });
+
+  it('trims whitespace-only nickname and reports it as empty', async () => {
+    const plugin = makeFakePlugin();
+    const modal = openModal(plugin);
+
+    await fillAndSubmit(modal, '   ', 'password');
+
+    expect(plugin.unlockVaultWithPassword).not.toHaveBeenCalled();
+    expect(findByText(modal.contentEl, 'Nickname required.')).toBe(true);
+  });
+});
+
+// ── Submit behavior ─────────────────────────────────
+describe('LoginModal — submit', () => {
+  it('on success: persists nickname, calls unlockVaultWithPassword, closes modal', async () => {
+    const plugin = makeFakePlugin();
+    const modal = openModal(plugin);
+
+    await fillAndSubmit(modal, 'daisy', 'correct-horse-battery-staple');
+
+    expect(plugin.settings.nickname).toBe('daisy');
+    expect(plugin.saveSettings).toHaveBeenCalled();
+    expect(plugin.unlockVaultWithPassword).toHaveBeenCalledWith('correct-horse-battery-staple');
+    expect(modal.close).toHaveBeenCalledOnce();
+  });
+
+  it('defaults serverUrl to https://silentstone.one when unset', async () => {
+    const plugin = makeFakePlugin({ serverUrl: '' });
+    const modal = openModal(plugin);
+
+    await fillAndSubmit(modal, 'daisy', 'password');
+
+    expect(plugin.settings.serverUrl).toBe('https://silentstone.one');
+  });
+
+  it('preserves custom serverUrl when already set', async () => {
+    const plugin = makeFakePlugin({ serverUrl: 'https://my-selfhosted.example.com' });
+    const modal = openModal(plugin);
+
+    await fillAndSubmit(modal, 'daisy', 'password');
+
+    expect(plugin.settings.serverUrl).toBe('https://my-selfhosted.example.com');
+  });
+
+  it('maps HTTP 401 to "Wrong nickname or password."', async () => {
+    const err = new Error('Invalid credentials') as Error & { status: number };
+    err.status = 401;
+    const plugin = makeFakePlugin();
+    plugin.unlockVaultWithPassword = vi.fn().mockRejectedValue(err);
+    const modal = openModal(plugin);
+
+    await fillAndSubmit(modal, 'daisy', 'wrong');
+
+    expect(modal.close).not.toHaveBeenCalled();
+    expect(findByText(modal.contentEl, 'Wrong nickname or password.')).toBe(true);
+  });
+
+  it('maps HTTP 403 to "Account pending approval or suspended."', async () => {
+    const err = new Error('Forbidden') as Error & { status: number };
+    err.status = 403;
+    const plugin = makeFakePlugin();
+    plugin.unlockVaultWithPassword = vi.fn().mockRejectedValue(err);
+    const modal = openModal(plugin);
+
+    await fillAndSubmit(modal, 'daisy', 'password');
+
+    expect(findByText(modal.contentEl, 'Account pending approval or suspended.')).toBe(true);
+  });
+
+  it('maps HTTP 429 to rate-limit message', async () => {
+    const err = new Error('Too many requests') as Error & { status: number };
+    err.status = 429;
+    const plugin = makeFakePlugin();
+    plugin.unlockVaultWithPassword = vi.fn().mockRejectedValue(err);
+    const modal = openModal(plugin);
+
+    await fillAndSubmit(modal, 'daisy', 'password');
+
+    expect(findByText(modal.contentEl, 'Too many attempts')).toBe(true);
+  });
+
+  it('maps "vault keys not set up" error to friendly first-time-setup prompt', async () => {
+    const plugin = makeFakePlugin();
+    plugin.unlockVaultWithPassword = vi
+      .fn()
+      .mockRejectedValue(new Error('Vault keys not set up on server. Run first-time setup.'));
+    const modal = openModal(plugin);
+
+    await fillAndSubmit(modal, 'daisy', 'password');
+
+    expect(findByText(modal.contentEl, 'No vault yet')).toBe(true);
+    expect(findByText(modal.contentEl, 'Vault: first-time setup')).toBe(true);
+  });
+
+  it('maps network errors to "Can\'t reach Silent Stone"', async () => {
+    const plugin = makeFakePlugin();
+    plugin.unlockVaultWithPassword = vi.fn().mockRejectedValue(new Error('fetch failed'));
+    const modal = openModal(plugin);
+
+    await fillAndSubmit(modal, 'daisy', 'password');
+
+    expect(findByText(modal.contentEl, "Can't reach Silent Stone")).toBe(true);
+  });
+
+  it('wraps unknown errors with "Sign in failed: ..." prefix', async () => {
+    const plugin = makeFakePlugin();
+    plugin.unlockVaultWithPassword = vi.fn().mockRejectedValue(new Error('something weird'));
+    const modal = openModal(plugin);
+
+    await fillAndSubmit(modal, 'daisy', 'password');
+
+    expect(findByText(modal.contentEl, 'Sign in failed: something weird')).toBe(true);
+  });
+
+  it('clears password field after failed login', async () => {
+    const plugin = makeFakePlugin();
+    plugin.unlockVaultWithPassword = vi.fn().mockRejectedValue(new Error('fetch failed'));
+    const modal = openModal(plugin);
+
+    await fillAndSubmit(modal, 'daisy', 'wrong-password');
+
+    const { password } = findHandlers();
+    expect(password?.inputEl.value).toBe('');
+  });
+});

--- a/src/ui/login-modal.ts
+++ b/src/ui/login-modal.ts
@@ -1,0 +1,189 @@
+import { App, Modal, Setting } from 'obsidian';
+import type SilentStoneSyncPlugin from '../main';
+
+const DEFAULT_SERVER_URL = 'https://silentstone.one';
+const SIGNUP_URL = 'https://silentstone.one/signup';
+
+export class LoginModal extends Modal {
+  private plugin: SilentStoneSyncPlugin;
+  private nickname = '';
+  private password = '';
+  private submitting = false;
+  private errorEl: HTMLElement | null = null;
+  private submitBtn: HTMLButtonElement | null = null;
+  private nicknameInputEl: HTMLInputElement | null = null;
+  private passwordInputEl: HTMLInputElement | null = null;
+
+  constructor(app: App, plugin: SilentStoneSyncPlugin) {
+    super(app);
+    this.plugin = plugin;
+    this.nickname = plugin.settings.nickname ?? '';
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+
+    contentEl.createEl('h2', { text: 'Sign in to Silent Stone' });
+    contentEl.createEl('p', {
+      text: 'Log in to your account to start syncing your vault.',
+      cls: 'setting-item-description',
+    });
+
+    new Setting(contentEl).setName('Nickname').addText((text) => {
+      text
+        .setPlaceholder('your nickname')
+        .setValue(this.nickname)
+        .onChange((v) => {
+          this.nickname = v;
+        });
+      text.inputEl.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          this.passwordInputEl?.focus();
+        }
+      });
+      this.nicknameInputEl = text.inputEl;
+    });
+
+    new Setting(contentEl).setName('Password').addText((text) => {
+      text.setPlaceholder('password').onChange((v) => {
+        this.password = v;
+      });
+      text.inputEl.type = 'password';
+      text.inputEl.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          void this.submit();
+        }
+      });
+      this.passwordInputEl = text.inputEl;
+    });
+
+    this.errorEl = contentEl.createEl('div', {
+      cls: 'mod-warning',
+      attr: { style: 'display:none;margin:0.5em 0;' },
+    });
+
+    new Setting(contentEl)
+      .addButton((btn) => {
+        btn.setButtonText('Log in').setCta();
+        btn.onClick(() => void this.submit());
+        this.submitBtn = btn.buttonEl;
+      })
+      .addButton((btn) => {
+        btn.setButtonText('Cancel');
+        btn.onClick(() => this.close());
+      });
+
+    const linkRow = contentEl.createEl('p', {
+      cls: 'setting-item-description',
+      attr: { style: 'text-align:center;margin-top:1em;' },
+    });
+    linkRow.createEl('span', { text: "Don't have an account? " });
+    const link = linkRow.createEl('a', {
+      text: 'Create one',
+      attr: {
+        href: SIGNUP_URL,
+        target: '_blank',
+        rel: 'noopener',
+      },
+    });
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      window.open(SIGNUP_URL, '_blank');
+    });
+
+    queueMicrotask(() => {
+      if (this.nickname) this.passwordInputEl?.focus();
+      else this.nicknameInputEl?.focus();
+    });
+  }
+
+  onClose(): void {
+    this.password = '';
+    this.contentEl.empty();
+  }
+
+  private async submit(): Promise<void> {
+    if (this.submitting) return;
+    const nickname = this.nickname.trim();
+    if (!nickname) {
+      this.showError('Nickname required.');
+      return;
+    }
+    if (!this.password) {
+      this.showError('Password required.');
+      return;
+    }
+
+    this.submitting = true;
+    this.hideError();
+    if (this.submitBtn) {
+      this.submitBtn.disabled = true;
+      this.submitBtn.textContent = 'Signing in…';
+    }
+
+    try {
+      if (!this.plugin.settings.serverUrl) {
+        this.plugin.settings.serverUrl = DEFAULT_SERVER_URL;
+      }
+      this.plugin.settings.nickname = nickname;
+      await this.plugin.saveSettings();
+
+      await this.plugin.unlockVaultWithPassword(this.password);
+      this.close();
+    } catch (e) {
+      this.showError(this.friendlyError(e));
+      if (this.passwordInputEl) {
+        this.passwordInputEl.value = '';
+        this.passwordInputEl.focus();
+      }
+      this.password = '';
+    } finally {
+      this.submitting = false;
+      if (this.submitBtn) {
+        this.submitBtn.disabled = false;
+        this.submitBtn.textContent = 'Log in';
+      }
+    }
+  }
+
+  private friendlyError(err: unknown): string {
+    const statusObj = err as { status?: number } | null;
+    if (statusObj && typeof statusObj.status === 'number') {
+      if (statusObj.status === 401) return 'Wrong nickname or password.';
+      if (statusObj.status === 403) return 'Account pending approval or suspended.';
+      if (statusObj.status === 429) return 'Too many attempts. Wait a minute and try again.';
+    }
+
+    const raw = err instanceof Error ? err.message : String(err);
+    const lower = raw.toLowerCase();
+
+    if (lower.includes('vault keys not set up')) {
+      return 'No vault yet. Run "Vault: first-time setup" from the command palette.';
+    }
+    if (
+      lower.includes('failed to fetch') ||
+      lower.includes('network') ||
+      lower.includes('enotfound') ||
+      lower.includes('econnrefused') ||
+      lower.includes('fetch failed')
+    ) {
+      return "Can't reach Silent Stone. Check your connection and server URL.";
+    }
+    return `Sign in failed: ${raw}`;
+  }
+
+  private showError(msg: string): void {
+    if (!this.errorEl) return;
+    this.errorEl.setText(msg);
+    this.errorEl.style.display = '';
+  }
+
+  private hideError(): void {
+    if (!this.errorEl) return;
+    this.errorEl.setText('');
+    this.errorEl.style.display = 'none';
+  }
+}


### PR DESCRIPTION
## Summary

First-run UX for vault sync. When the plugin loads with no Bearer token persisted, it now auto-opens a login modal on layout-ready so fresh-install users aren't left hunting through the command palette. Closes #5.

- **New** `src/ui/login-modal.ts` — extends Obsidian `Modal`. Fields: nickname, password. Buttons: Log in, Cancel. Plus a "Create account" link to `https://silentstone.one/signup`.
- **New** `src/ui/__tests__/login-modal.test.ts` — 18 tests covering render, validation (empty/whitespace nickname, empty password), all friendly-error branches (401/403/429/"keys not set up"/network/generic), and happy path.
- **Modified** `src/main.ts` — auto-popup trigger in `onload()` (only when `vaultAuthToken` empty, deferred until `workspace.onLayoutReady`), plus a new `Vault: log in` command for users who cancel and want to retry.

## What users feel

Install plugin v0.1.5 → open Obsidian → modal pops up automatically asking for nickname + password. No command-palette archaeology needed. On success, plugin lands fully unlocked and ready to sync. On cancel, plugin stays unconfigured; the `Vault: log in` command is available anytime to re-open.

## Why reuse `unlockVaultWithPassword` instead of calling `createToken` directly

The spec in issue #5 said "On submit: calls `vaultClient.createToken(nickname, password)`". But `main.ts` already has `unlockVaultWithPassword()` that:
1. Calls `createToken` with a proper device label (`obsidian-${manifest.id}`)
2. Persists the token to `data.json`
3. Fetches vault keys, unwraps master key with the supplied password
4. Arms the sync runtime (manifest manager + watcher + sync engine)

Calling `createToken` directly from the modal would leave the plugin in a half-authenticated state — token persisted, but master key not derived, sync engine not armed. Reusing `unlockVaultWithPassword` gives us the full login+unlock in one shot with zero duplicated logic, and the modal becomes a thin UI shell.

## Friendly error mapping

| Server signal | Modal message |
|---|---|
| HTTP 401 | "Wrong nickname or password." |
| HTTP 403 | "Account pending approval or suspended." |
| HTTP 429 | "Too many attempts. Wait a minute and try again." |
| "Vault keys not set up on server" | 'No vault yet. Run "Vault: first-time setup" from the command palette.' |
| Network / fetch failed / ENOTFOUND / ECONNREFUSED | "Can't reach Silent Stone. Check your connection and server URL." |
| Other | "Sign in failed: \<raw error\>" |

## Test plan

- [x] `npm run lint` — 0 errors (3 pre-existing warnings in unrelated `setup-modal.test.ts`)
- [x] `npm run typecheck` — clean
- [x] `npm test` — 181/181 passing (was 163 on main; +18 for this modal)
- [ ] **Daniel-side manual test** (post-release via BRAT):
  - [ ] Fresh install → modal auto-opens on Obsidian layout-ready
  - [ ] Wrong credentials → inline error, modal stays open, password field cleared
  - [ ] Correct credentials with vault keys already set up → modal closes, plugin unlocked, sync engine armed
  - [ ] Correct credentials but no vault yet → friendly "No vault yet" message, pointer to first-time setup
  - [ ] "Create one" link → opens `silentstone.one/signup` in system browser
  - [ ] Cancel button → modal closes, plugin stays unconfigured, status bar reads "SS: Not connected"
  - [ ] Command palette → "Vault: log in" re-opens modal

## Out of scope (separate issues)

- #11 single-vault safety guard (sync-layer + possible server endpoint)
- #3 status bar state matrix (needs spec pass on 5 states)
- P5 vault-list fetch after login (v0.4 multi-vault work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)