### PR TITLE
feat(plugin): wire vault engine to default UI + auto-chain first run

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -46,8 +46,8 @@ export default class SilentStoneSyncPlugin extends Plugin {
 
     // Commands
     this.addCommand({
-      id: 'sync-now',
-      name: 'Sync vault now',
+      id: 'legacy-syncthing-sync-now',
+      name: 'Legacy Syncthing: sync now',
       callback: () => this.triggerSync(),
     });
 
@@ -76,8 +76,8 @@ export default class SilentStoneSyncPlugin extends Plugin {
     });
 
     this.addCommand({
-      id: 'vault-sync-now',
-      name: 'Vault: sync now (E2E encrypted)',
+      id: 'sync-now',
+      name: 'Sync vault now',
       callback: () => this.triggerVaultSync(),
     });
 
@@ -89,7 +89,7 @@ export default class SilentStoneSyncPlugin extends Plugin {
 
     // Ribbon icon
     this.addRibbonIcon('cloud', 'Sync with Silent Stone', () => {
-      this.triggerSync();
+      this.triggerVaultSync();
     });
 
     // Initialize client if configured
@@ -104,15 +104,19 @@ export default class SilentStoneSyncPlugin extends Plugin {
     }
 
     // Rehydrate vault client from persisted Bearer token (v0.3).
-    // Master key is NOT persisted — the plugin lands in a "connected but
-    // locked" state. User must run "Vault: unlock with password" before any
-    // sync can happen. This is what lets the Test button and status bar
-    // report connectivity accurately across reloads.
+    // Master key is NOT persisted by design — plugin lands in a "connected
+    // but locked" state on every reload. Rehydrating the client (without
+    // a key) lets the Test button + status bar report accurate connectivity;
+    // auto-popping the unlock modal gives the user a one-click path to
+    // arming the runtime without hunting through the command palette.
     if (this.settings.serverUrl && this.settings.vaultAuthToken) {
       this.vaultClient = new VaultClient(
         this.settings.serverUrl,
         this.settings.vaultAuthToken,
       );
+      this.app.workspace.onLayoutReady(() => {
+        new UnlockModal(this.app, this).open();
+      });
     } else if (!this.settings.vaultAuthToken) {
       // First-run UX: no Bearer token persisted → auto-popup login modal so
       // the user isn't left hunting through the command palette. Deferred via

--- a/src/ui/__tests__/login-modal.test.ts
+++ b/src/ui/__tests__/login-modal.test.ts
@@ -194,6 +194,12 @@ const { MockModal, MockSetting, lastSettings } = vi.hoisted(() => {
   return { MockModal, MockSetting, lastSettings };
 });
 
+vi.mock('../setup-modal', () => ({
+  SetupModal: vi.fn(function () {
+    return { open: vi.fn() };
+  }),
+}));
+
 vi.mock('obsidian', () => ({
   App: class {},
   Modal: MockModal,
@@ -201,12 +207,14 @@ vi.mock('obsidian', () => ({
 }));
 
 import { LoginModal } from '../login-modal';
+import { SetupModal } from '../setup-modal';
 
 // ── Test helpers ───────────────────────────────────
 type FakePlugin = {
   settings: { serverUrl: string; nickname: string; vaultAuthToken: string };
   saveSettings: ReturnType<typeof vi.fn>;
   unlockVaultWithPassword: ReturnType<typeof vi.fn>;
+  triggerVaultSync: ReturnType<typeof vi.fn>;
 };
 
 function makeFakePlugin(overrides: Partial<FakePlugin['settings']> = {}): FakePlugin {
@@ -219,6 +227,7 @@ function makeFakePlugin(overrides: Partial<FakePlugin['settings']> = {}): FakePl
     },
     saveSettings: vi.fn().mockResolvedValue(undefined),
     unlockVaultWithPassword: vi.fn().mockResolvedValue(undefined),
+    triggerVaultSync: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -430,7 +439,7 @@ describe('LoginModal — submit', () => {
     expect(findByText(modal.contentEl, 'Too many attempts')).toBe(true);
   });
 
-  it('maps "vault keys not set up" error to friendly first-time-setup prompt', async () => {
+  it('routes to first-time setup wizard when vault keys not set up server-side', async () => {
     const plugin = makeFakePlugin();
     plugin.unlockVaultWithPassword = vi
       .fn()
@@ -439,8 +448,9 @@ describe('LoginModal — submit', () => {
 
     await fillAndSubmit(modal, 'daisy', 'password');
 
-    expect(findByText(modal.contentEl, 'No vault yet')).toBe(true);
-    expect(findByText(modal.contentEl, 'Vault: first-time setup')).toBe(true);
+    expect(modal.close).toHaveBeenCalled();
+    expect(SetupModal).toHaveBeenCalledWith(modal.app, plugin);
+    expect(findByText(modal.contentEl, 'No vault yet')).toBe(false);
   });
 
   it('maps network errors to "Can\'t reach Silent Stone"', async () => {

--- a/src/ui/__tests__/setup-modal.test.ts
+++ b/src/ui/__tests__/setup-modal.test.ts
@@ -247,6 +247,7 @@ type FakePlugin = {
   settings: { serverUrl: string; nickname: string };
   generateVaultMaterial: ReturnType<typeof vi.fn>;
   commitVaultSetup: ReturnType<typeof vi.fn>;
+  triggerVaultSync: ReturnType<typeof vi.fn>;
 };
 
 const SAMPLE_PHRASE =
@@ -276,6 +277,7 @@ function makeFakePlugin(overrides: Partial<FakePlugin> = {}): FakePlugin {
       pendingSetup: makePendingSetup(),
     }),
     commitVaultSetup: vi.fn().mockResolvedValue(undefined),
+    triggerVaultSync: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }

--- a/src/ui/__tests__/unlock-modal.test.ts
+++ b/src/ui/__tests__/unlock-modal.test.ts
@@ -185,6 +185,7 @@ import { UnlockModal } from '../unlock-modal';
 type FakePlugin = {
 	settings: { serverUrl: string; nickname: string };
 	unlockVaultWithPassword: ReturnType<typeof vi.fn>;
+	triggerVaultSync: ReturnType<typeof vi.fn>;
 };
 
 function makeFakePlugin(overrides: Partial<FakePlugin> = {}): FakePlugin {
@@ -194,6 +195,7 @@ function makeFakePlugin(overrides: Partial<FakePlugin> = {}): FakePlugin {
 			nickname: 'tester',
 		},
 		unlockVaultWithPassword: vi.fn().mockResolvedValue(undefined),
+		triggerVaultSync: vi.fn().mockResolvedValue(undefined),
 		...overrides,
 	};
 }

--- a/src/ui/login-modal.ts
+++ b/src/ui/login-modal.ts
@@ -1,5 +1,6 @@
 import { App, Modal, Setting } from 'obsidian';
 import type SilentStoneSyncPlugin from '../main';
+import { SetupModal } from './setup-modal';
 
 const DEFAULT_SERVER_URL = 'https://silentstone.one';
 const SIGNUP_URL = 'https://silentstone.one/signup';
@@ -133,7 +134,14 @@ export class LoginModal extends Modal {
 
       await this.plugin.unlockVaultWithPassword(this.password);
       this.close();
+      void this.plugin.triggerVaultSync();
     } catch (e) {
+      // No keys server-side → new vault. Route to setup instead of erroring.
+      if (e instanceof Error && e.message.includes('Vault keys not set up')) {
+        this.close();
+        new SetupModal(this.app, this.plugin).open();
+        return;
+      }
       this.showError(this.friendlyError(e));
       if (this.passwordInputEl) {
         this.passwordInputEl.value = '';

--- a/src/ui/setup-modal.ts
+++ b/src/ui/setup-modal.ts
@@ -288,6 +288,7 @@ export class SetupModal extends Modal {
       this.recoveryPhrase = null;
       this.step = 3;
       this.renderStep();
+      void this.plugin.triggerVaultSync();
     } catch (e) {
       const raw = e instanceof Error ? e.message : String(e);
       this.showError(this.friendlyError(raw));

--- a/src/ui/unlock-modal.ts
+++ b/src/ui/unlock-modal.ts
@@ -84,6 +84,7 @@ export class UnlockModal extends Modal {
     try {
       await this.plugin.unlockVaultWithPassword(this.password);
       this.close();
+      void this.plugin.triggerVaultSync();
     } catch (e) {
       const raw = e instanceof Error ? e.message : String(e);
       const friendly = this.friendlyError(raw);


### PR DESCRIPTION
## Summary

Closes #22, closes #23.

The vault sync engine works (PR #140 + plugin v0.1.5), but its default UI surfaces — ribbon icon and `sync-now` command — were wired to legacy Syncthing code that dead-ends with "Full sync not yet implemented." After auto-popup login, users had to manually find `vault-setup` → `vault-unlock` → `vault-sync-now` in Cmd+P with no signposting.

This PR wires the default UI to the vault engine and auto-chains the first-run flow so a fresh BRAT install completes first sync without any Cmd+P hunt.

## What changed

**Command rewire** (`src/main.ts`):
- Legacy `id: 'sync-now'` renamed to `id: 'legacy-syncthing-sync-now', name: 'Legacy Syncthing: sync now'` — Syncthing code preserved (not deleted) for future admin-repo relocation.
- Vault `id: 'vault-sync-now'` promoted to canonical `id: 'sync-now', name: 'Sync vault now'`.
- Cloud ribbon callback: `triggerSync()` → `triggerVaultSync()`.

**First-run auto-chain** (modals):
- `LoginModal`: catches the existing `"Vault keys not set up on server"` error from `unlockVaultWithPassword` and routes to `SetupModal` instead of showing it as an error. After successful unlock, fires `triggerVaultSync()`.
- `SetupModal`: after `commitVaultSetup` resolves, fires `triggerVaultSync()` (background) so sync runs while step 3 displays.
- `UnlockModal`: after successful unlock, fires `triggerVaultSync()`.

**Reload UX** (`src/main.ts onload`):
- When `vaultAuthToken` is persisted but no master key is in memory (every Obsidian reload by design), auto-popup `UnlockModal` mirroring the existing first-run `LoginModal` popup.

## End-to-end UX after this lands

| State | Behavior |
|-------|----------|
| Fresh install | Login modal auto-opens → enter credentials → SetupModal opens → enter password, save recovery phrase, confirm → first sync runs automatically |
| Existing vault, fresh session | Login modal auto-opens → enter credentials → unlock succeeds → sync runs automatically |
| Reload with stored token | UnlockModal auto-opens → enter password → sync runs automatically |
| Click cloud ribbon | Runs `triggerVaultSync()` (vault engine) instead of dead Syncthing path |

## What's preserved

Per Daniel's instruction "keep syncthing code for its own repo," **no Syncthing code is deleted**:
- `triggerSync()`, `SilentStoneClient`, `client` field, `loadSettings`/`onload` reinit branch, `checkConnection()` — all untouched.
- The legacy `Legacy Syncthing: sync now` command remains registered and functional via the command palette.

## Test plan

- [x] `npm run lint` — 0 errors (3 pre-existing warnings unrelated)
- [x] `npx tsc --noEmit` filtered to `src/` — clean
- [x] `npm test` — 181/181 passing
- [x] `npm run build` — clean
- [ ] Manual smoke test: fresh Obsidian vault, install via BRAT against `dev.silentstone.one`, complete login → setup → recovery phrase → confirm sync round-trips a note (this PR is the unblocker — Daniel will run this once merged)
- [ ] Manual smoke test: Obsidian reload with stored token → UnlockModal auto-opens → password unlocks → sync runs

## Test changes

- Added `triggerVaultSync: vi.fn().mockResolvedValue(undefined)` to fake plugins in `login-modal.test.ts`, `setup-modal.test.ts`, `unlock-modal.test.ts` (required for the new `void this.plugin.triggerVaultSync()` calls).
- Mocked `SetupModal` in `login-modal.test.ts` so the test can assert routing without instantiating the real wizard.
- Updated the "vault keys not set up" test to assert `SetupModal` was opened (new behavior) instead of the friendly error display (old behavior).

## Out of scope (deferred)

- `#3` Status bar full state matrix — works as-is for first sync via existing `onStatusChange` callback
- `#4` Broader settings UI restructure (Account/Vault/Sync/Conflict blocks, dev-mode toggle, server URL field gating) — this PR ships the command-rename subset; #4 picks up the rest
- `#6` OS keychain persistence — would skip the unlock prompt on reload
- `#11` Single-vault safety guard — needed for second-device sync, not first-sync
- `silent-stone#145` Recovery-phrase restore — gates second-device sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR wires the vault engine to the default UI and implements automatic sync triggers across first-run flows, addressing the blocking issues for vault engine integration (#22, #23).

### Command and Ribbon Rewiring

- Renamed the legacy `sync-now` command to `legacy-syncthing-sync-now`, preserving existing Syncthing functionality while preventing it from being the default surface.
- Promoted the `vault-sync-now` command to the canonical `sync-now` command that invokes `triggerVaultSync()` for encrypted E2E sync.
- Updated the cloud ribbon icon to trigger `triggerVaultSync()` instead of the legacy sync path.

### First-Run Auto-Chain

- **LoginModal**: When `unlockVaultWithPassword` fails with the "Vault keys not set up on server" error, the modal now closes and automatically opens `SetupModal` instead of displaying an error. On successful unlock, `triggerVaultSync()` is called.
- **SetupModal**: After `commitVaultSetup` resolves, `triggerVaultSync()` is triggered (fire-and-forget) while step 3 displays, enabling sync to run in the background during the "Vault created" state.
- **UnlockModal**: After successful unlock, `triggerVaultSync()` is called to start the sync process automatically.

### Reload UX

When a persisted `vaultAuthToken` exists but no master key is in memory, `UnlockModal` auto-opens on `workspace.onLayoutReady`, streamlining the "connected but locked" session resumption flow.

### End-to-End User Flows

- **Fresh install**: Login → SetupModal → password/recovery phrase entry → first sync runs automatically
- **Existing vault, fresh session**: Login → unlock → sync runs automatically
- **Reload with stored token**: UnlockModal auto-opens → unlock → sync runs automatically
- **Cloud ribbon and default sync command**: Now trigger vault engine; legacy Syncthing command remains available

### Testing and Build

- Added `triggerVaultSync` mocks to test fixtures (login, setup, unlock modals)
- Updated LoginModal tests to verify SetupModal routing on vault-not-setup errors
- Lint, typecheck, build, and automated tests pass; legacy Syncthing code remains intact

<!-- end of auto-generated comment: release notes by coderabbit.ai -->