### PR TITLE
fix(sync): pushChanges enumerates vault — initial-sync uploads pre-existing files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import type { WrappedKey } from './crypto/types';
 import { ManifestManager } from './sync/manifest';
 import { FileWatcher } from './sync/watcher';
 import { SyncEngine } from './sync/engine';
+import { compileIgnorePrefixes, isIgnored } from './sync/ignore';
 import { LoginModal } from './ui/login-modal';
 import { SetupModal } from './ui/setup-modal';
 import { UnlockModal } from './ui/unlock-modal';
@@ -383,6 +384,8 @@ export default class SilentStoneSyncPlugin extends Plugin {
     });
     watcher.start();
 
+    const ignorePrefixes = compileIgnorePrefixes(this.settings.ignorePaths);
+
     const persisted = (await this.loadData()) ?? {};
     const knownSynced = new Set<string>(persisted[KNOWN_SYNCED_KEY] ?? []);
 
@@ -402,6 +405,11 @@ export default class SilentStoneSyncPlugin extends Plugin {
         delete: async (path) => {
           await this.app.vault.adapter.remove(path);
         },
+        listAll: async () =>
+          this.app.vault
+            .getFiles()
+            .map((f) => f.path)
+            .filter((p) => !isIgnored(p, ignorePrefixes)),
       },
       masterKey,
       knownSynced,

--- a/src/sync/__tests__/engine.test.ts
+++ b/src/sync/__tests__/engine.test.ts
@@ -73,6 +73,10 @@ class FakeVault implements SyncVault {
   async delete(path: string): Promise<void> {
     this.files.delete(path);
   }
+
+  async listAll(): Promise<string[]> {
+    return [...this.files.keys()];
+  }
 }
 
 class FakeQueue {
@@ -682,5 +686,108 @@ describe('SyncEngine.sync — final metrics event + observability ping', () => {
     expect(errorEvent).toBeDefined();
     expect(errorEvent!.errorMessage).toBeDefined();
     expect(typeof errorEvent!.errorMessage).toBe('string');
+  });
+});
+
+// ── pushChanges — trust-the-sync regression ────────
+// Three regression tests for the v0.1.7 bug: pushChanges() relied entirely on
+// watcher.getQueue(), so pre-existing vault files (created before watcher.start
+// ever ran) were never enumerated and never uploaded. The UI still reported
+// "Synced — Files: 0" and the server saw 0 B. After the fix, pushChanges
+// enumerates vault.listAll(), diffs against the manifest, and uploads the gap.
+describe('SyncEngine.pushChanges — pre-existing vault files (no watcher events)', () => {
+  it('uploads files that exist locally but are missing from the manifest, even with empty queue', async () => {
+    const h = await makeHarness();
+    const a = new TextEncoder().encode('alpha').buffer as ArrayBuffer;
+    const b = new TextEncoder().encode('beta').buffer as ArrayBuffer;
+    const c = new TextEncoder().encode('gamma').buffer as ArrayBuffer;
+    h.vault.files.set('a.md', a);
+    h.vault.files.set('b.md', b);
+    h.vault.files.set('c.md', c);
+    h.queue.events = []; // The smoking gun.
+
+    // 3 putBlob + 1 putManifest
+    mockRequestUrl.mockResolvedValueOnce(okJson({ ok: true, blobId: 'x', size: 5 }));
+    mockRequestUrl.mockResolvedValueOnce(okJson({ ok: true, blobId: 'x', size: 4 }));
+    mockRequestUrl.mockResolvedValueOnce(okJson({ ok: true, blobId: 'x', size: 5 }));
+    mockRequestUrl.mockResolvedValueOnce(okJson({ ok: true, sequenceNumber: 1 }));
+
+    await h.engine.pushChanges();
+
+    const blobCalls = mockRequestUrl.mock.calls.filter((call) => {
+      const args = call[0] as { method: string; url: string };
+      return args.method === 'PUT' && /\/api\/vault\/blobs\/[0-9a-f-]{36}$/.test(args.url);
+    });
+    expect(blobCalls).toHaveLength(3);
+
+    const manifestCall = mockRequestUrl.mock.calls.find((call) => {
+      const args = call[0] as { method: string; url: string };
+      return args.method === 'PUT' && args.url.endsWith('/api/vault/manifest');
+    });
+    expect(manifestCall).toBeDefined();
+
+    expect(h.manifest.getEntry('a.md')).toBeDefined();
+    expect(h.manifest.getEntry('b.md')).toBeDefined();
+    expect(h.manifest.getEntry('c.md')).toBeDefined();
+  });
+});
+
+describe('SyncEngine.pushChanges — deletion via diff with knownSynced guard', () => {
+  it('deletes blobs for files in manifest + knownSynced that are missing locally, with no watcher event', async () => {
+    const h = await makeHarness({ knownSynced: new Set(['a.md', 'b.md']) });
+
+    const a = new TextEncoder().encode('alpha').buffer as ArrayBuffer;
+    h.vault.files.set('a.md', a);
+
+    const aHash = await sha256Hex(a);
+    h.manifest.setEntry('a.md', {
+      blobId: '11111111-1111-4111-8111-111111111111',
+      size: a.byteLength,
+      hash: aHash,
+      modifiedAt: 1,
+    });
+    const bBlobId = '22222222-2222-4222-8222-222222222222';
+    h.manifest.setEntry('b.md', {
+      blobId: bBlobId,
+      size: 4,
+      hash: 'beta-hash',
+      modifiedAt: 1,
+    });
+    h.queue.events = []; // diff-driven, no watcher event
+
+    mockRequestUrl.mockResolvedValueOnce(okJson({ ok: true })); // deleteBlob b
+    mockRequestUrl.mockResolvedValueOnce(okJson({ ok: true, sequenceNumber: 1 })); // manifest
+
+    await h.engine.pushChanges();
+
+    const deleteCall = mockRequestUrl.mock.calls.find((call) => {
+      const args = call[0] as { method: string; url: string };
+      return args.method === 'DELETE' && args.url.endsWith(bBlobId);
+    });
+    expect(deleteCall).toBeDefined();
+    expect(h.manifest.getEntry('b.md')).toBeUndefined();
+    expect(h.manifest.getEntry('a.md')).toBeDefined();
+  });
+});
+
+describe('SyncEngine.pushChanges — orphan guard', () => {
+  it('does NOT delete a manifest entry that was never in knownSynced and has no watcher delete event', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const h = await makeHarness(); // empty knownSynced
+
+    h.manifest.setEntry('orphan.md', {
+      blobId: '33333333-3333-4333-8333-333333333333',
+      size: 10,
+      hash: 'orphan-hash',
+      modifiedAt: 1,
+    });
+    h.queue.events = []; // no watcher hint
+
+    await h.engine.pushChanges();
+
+    expect(mockRequestUrl).not.toHaveBeenCalled();
+    expect(h.manifest.getEntry('orphan.md')).toBeDefined();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 });

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -14,6 +14,8 @@ export interface SyncVault {
   create(path: string, data: ArrayBuffer): Promise<void>;
   modify(path: string, data: ArrayBuffer): Promise<void>;
   delete(path: string): Promise<void>;
+  /** Vault-relative paths of every syncable file currently on disk. */
+  listAll(): Promise<string[]>;
 }
 
 export interface QueueSource {
@@ -136,48 +138,72 @@ export class SyncEngine {
   async pushChanges(): Promise<void> {
     this.emit('syncing');
     try {
-      const events = this.watcher.getQueue();
-      if (events.length === 0) {
-        this.emit('idle');
-        return;
+      // Source of truth for "what should exist server-side": every file
+      // currently on disk in the vault. The watcher queue used to be the
+      // only signal here, which silently lost pre-existing files because
+      // the watcher only fires on events AFTER it starts listening.
+      const paths = await this.vault.listAll();
+      const localFiles = new Map<string, string>();
+      const localContents = new Map<string, ArrayBuffer>();
+      for (const path of paths) {
+        const data = await this.vault.readBinary(path);
+        localContents.set(path, data);
+        localFiles.set(path, await sha256Hex(data));
+      }
+
+      const { toUpload, toDelete: diffDeletes } = this.manifest.diff(localFiles);
+
+      // Watcher delete events still carry strong "user just deleted this"
+      // intent. Combined with knownSynced, they gate the deletion path:
+      // only delete blobs the user has either synced before OR explicitly
+      // removed in Obsidian. Anything else is treated as an orphan and
+      // preserved with a warning (see Issue #164 — tombstone tracking).
+      const watcherDeletes = new Set<string>();
+      for (const ev of this.watcher.getQueue()) {
+        if (ev.kind === 'delete') watcherDeletes.add(ev.path);
       }
 
       const pendingSets: Array<[string, ManifestEntry]> = [];
       const pendingDeletes: string[] = [];
 
-      for (const ev of events) {
-        if (ev.kind === 'upsert') {
-          if (!(await this.vault.exists(ev.path))) continue;
+      for (const path of toUpload) {
+        const plaintext = localContents.get(path)!;
+        const hash = localFiles.get(path)!;
+        const existing = this.manifest.getEntry(path);
+        const blobId = existing?.blobId ?? crypto.randomUUID();
+        const encrypted = await encryptBlob(new Uint8Array(plaintext), this.masterKey);
+        await this.client.putBlob(blobId, toArrayBuffer(encrypted));
 
-          const plaintext = await this.vault.readBinary(ev.path);
-          const hash = await sha256Hex(plaintext);
-          const existing = this.manifest.getEntry(ev.path);
-          if (existing && existing.hash === hash) continue;
+        const entry: ManifestEntry = {
+          blobId,
+          size: plaintext.byteLength,
+          hash,
+          modifiedAt: Date.now(),
+        };
+        this.manifest.setEntry(path, entry);
+        pendingSets.push([path, entry]);
+      }
 
-          const blobId = existing?.blobId ?? crypto.randomUUID();
-          const encrypted = await encryptBlob(new Uint8Array(plaintext), this.masterKey);
-          await this.client.putBlob(blobId, toArrayBuffer(encrypted));
-
-          const entry: ManifestEntry = {
-            blobId,
-            size: plaintext.byteLength,
-            hash,
-            modifiedAt: Date.now(),
-          };
-          this.manifest.setEntry(ev.path, entry);
-          pendingSets.push([ev.path, entry]);
-        } else if (ev.kind === 'delete') {
-          const existing = this.manifest.getEntry(ev.path);
-          if (!existing) continue;
-          await this.client.deleteBlob(existing.blobId);
-          this.manifest.deleteEntry(ev.path);
-          pendingDeletes.push(ev.path);
+      for (const path of diffDeletes) {
+        if (!this.knownSynced.has(path) && !watcherDeletes.has(path)) {
+          console.warn(
+            '[silent-stone] orphaned manifest entry preserved (not in knownSynced):',
+            path,
+          );
+          continue;
         }
+        const existing = this.manifest.getEntry(path);
+        if (!existing) continue;
+        await this.client.deleteBlob(existing.blobId);
+        this.manifest.deleteEntry(path);
+        pendingDeletes.push(path);
       }
 
       const mutated = pendingSets.length > 0 || pendingDeletes.length > 0;
       if (mutated) {
         await this.saveWithRetry(pendingSets, pendingDeletes);
+        this.knownSynced = new Set(this.manifest.getAllEntries().keys());
+        if (this.onStateUpdate) await this.onStateUpdate(new Set(this.knownSynced));
       }
 
       this.watcher.clearQueue();

--- a/src/sync/ignore.ts
+++ b/src/sync/ignore.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared ignore-path filter used by both the file watcher and the sync engine's
+ * vault enumerator. Keeps both layers consistent on what counts as syncable.
+ *
+ * Currently only supports the `dir/**` prefix form. Glob expansion can be added
+ * later if real users need it.
+ */
+
+export const DEFAULT_IGNORE_PATHS = ['.obsidian/**', '.trash/**', '.git/**'];
+
+export function compileIgnorePrefixes(patterns: string[] | undefined): string[] {
+  return (patterns ?? DEFAULT_IGNORE_PATHS)
+    .filter((p) => p.endsWith('/**'))
+    .map((p) => p.slice(0, -3));
+}
+
+export function isIgnored(path: string, prefixes: string[]): boolean {
+  return prefixes.some((prefix) => path.startsWith(prefix));
+}

--- a/src/sync/watcher.ts
+++ b/src/sync/watcher.ts
@@ -1,3 +1,5 @@
+import { compileIgnorePrefixes, isIgnored } from './ignore';
+
 /**
  * One unit of work for the sync engine.
  * Rename is decomposed into delete(oldPath) + upsert(newPath) at emit time.
@@ -31,7 +33,6 @@ export interface FileWatcherOptions {
   debounceMs?: number;
 }
 
-const DEFAULT_IGNORE_PATHS = ['.obsidian/**', '.trash/**', '.git/**'];
 const DEFAULT_DEBOUNCE_MS = 2000;
 
 /**
@@ -50,10 +51,7 @@ export class FileWatcher {
     private readonly vault: VaultEventSource,
     opts: FileWatcherOptions = {},
   ) {
-    const patterns = opts.ignorePaths ?? DEFAULT_IGNORE_PATHS;
-    this.ignorePrefixes = patterns
-      .filter((p) => p.endsWith('/**'))
-      .map((p) => p.slice(0, -3));
+    this.ignorePrefixes = compileIgnorePrefixes(opts.ignorePaths);
     this.debounceMs = opts.debounceMs ?? DEFAULT_DEBOUNCE_MS;
   }
 
@@ -97,6 +95,6 @@ export class FileWatcher {
   }
 
   private isIgnored(path: string): boolean {
-    return this.ignorePrefixes.some((prefix) => path.startsWith(prefix));
+    return isIgnored(path, this.ignorePrefixes);
   }
 }


### PR DESCRIPTION
## Summary

`pushChanges()` returned early on every first sync because it only read from `watcher.getQueue()`, which captures events that fire *after* `watcher.start()`. Pre-existing files (daily notes, Welcome.md, anything created before the plugin loaded) never entered the queue. The engine emitted `'idle'`, the UI cheerfully reported "Vault synced — Files: 0", and the server saw 0 B because nothing was ever uploaded.

This was the central bug that v0.1.7's "trust-the-sync" UI sprint turned into visible dishonesty: the polished status badge was confidently lying.

## Fix

Rewrites `pushChanges()` to use `vault.listAll()` as the source of truth for what should exist server-side, then computes the diff against the manifest via the existing `manifest.diff()` helper (which was already written but never wired in — discovered during recon).

- `SyncVault` interface gains `listAll(): Promise<string[]>`
- `main.ts` adapter implements it via `app.vault.getFiles()` with the same ignore-path filter the watcher uses (extracted to a shared `src/sync/ignore.ts` helper)
- Watcher events are demoted from "the signal" to "a hint" — their `delete` events still gate the deletion path alongside `knownSynced`, so explicit user deletions in Obsidian still propagate
- Files in the manifest but missing locally with neither a watcher delete nor a `knownSynced` entry are treated as orphans and preserved with `console.warn` (Issue #164 territory — proper tombstone tracking is the real fix)
- After a mutating push, `knownSynced` is refreshed from the manifest and persisted via `onStateUpdate` so deletions across plugin reloads still gate correctly

## Tests (TDD — failing tests first, then implementation)

3 new regression tests in `src/sync/__tests__/engine.test.ts`:

1. **`pushChanges — pre-existing vault files (no watcher events)`** — vault has 3 files, queue empty, manifest empty → expects 3 blob PUTs + 1 manifest PUT + 3 manifest entries
2. **`pushChanges — deletion via diff with knownSynced guard`** — vault missing one file, manifest has it, knownSynced has it → expects 1 DELETE blob + manifest update
3. **`pushChanges — orphan guard`** — manifest has entry, knownSynced empty, queue empty → expects 0 network calls + `console.warn` fired

All three failed before the implementation. All three pass now. Test count: **199 → 202**, no regressions in the existing suite.

## Companion server PR

[`silent-stone#192`](https://github.com/josemoreno801-netizen/silent-stone/pull/192) (merged): adds defensive `dbUpsertVaultMetadata` in `blob-handlers.ts` so the dashboard storage counter doesn't silently no-op when uploads land for a nickname without a metadata row.

## Test plan

- [x] `npm test` — all 202 tests green locally
- [x] `npm run lint` — 0 errors (3 pre-existing `any`-warnings in `setup-modal.test.ts`, untouched)
- [x] `npm run typecheck` — clean for `src/`
- [ ] CI green
- [ ] After merge: `npm version patch` from `main` to cut `plugin-v0.1.8` → BRAT picks it up
- [ ] Manual round-trip test on Test-Dev vault against `dev.silentstone.one`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix for Initial Sync Uploading Zero Files

**Problem**: `pushChanges()` relied exclusively on `watcher.getQueue()` to determine what files to upload. Files existing in the vault before the watcher started listening were never enumerated, causing initial sync to report zero files uploaded and zero bytes transmitted.

**Solution**: Treat vault enumeration as the source of truth. `pushChanges()` now:
- Calls `vault.listAll()` to enumerate every syncable file on disk
- Computes diffs via `manifest.diff(localFiles)` to derive upload and deletion targets
- Uploads via existing encrypted blob mechanism
- Guards deletions with a two-gate check: file must be in `knownSynced` OR have a watcher delete event; orphaned manifest entries (never synced, no delete event) are logged and preserved

**Implementation Details**:
- New `SyncVault.listAll(): Promise<string[]>` interface method
- `src/sync/ignore.ts` extracts shared ignore-path helpers (`compileIgnorePrefixes`, `isIgnored`) for consistent filtering across watcher and vault enumerator
- `main.ts` adapter implements `listAll()` via `app.vault.getFiles()` with ignore-path filtering applied
- Watcher delegates ignore logic to centralized helpers
- After successful mutation, `knownSynced` is refreshed from manifest and persisted via `onStateUpdate` to maintain deletion guards across reloads

**Test Coverage**: Three regression tests confirm:
1. Pre-existing files upload when watcher queue is empty
2. Diff-driven deletions respect `knownSynced` guard
3. Orphan entries are preserved with console warning, no network calls

**Metrics**: +107 test LOC (3 new regressions), 199 → 202 total tests. All local npm test/lint/typecheck pass. Companion server PR (silent-stone#192) adds defensive upsert for dashboard file counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->