### PR TITLE
docs: scrub obsidian-plugin/ path rot and broken server-repo refs (#29)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ src/
 
 ## Server API Dependencies
 
-Two API clients, two product tracks (see `docs/API_ENDPOINTS.md`):
+Two API clients, two product tracks (see `docs/DEV.md` § 7 + § 10 for plugin-side mapping):
 
 ### Syncthing Track (`SilentStoneClient` in `api/client.ts`)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -231,16 +231,13 @@ Silent Stone's rate limiter (`rate-limit.ts`) has these limits relevant to the p
 
 ## File Structure
 
-See `obsidian-plugin/CLAUDE.md` for agent instructions and the full scaffold directory structure.
+See [`../CLAUDE.md`](../CLAUDE.md) for agent instructions and the full scaffold directory structure.
 
 ---
 
 ## Related Documents
 
-- [OBSIDIAN_PLUGIN_DEV.md](./OBSIDIAN_PLUGIN_DEV.md) — Plugin API reference
-- [API_ENDPOINTS.md](./API_ENDPOINTS.md) — Silent Stone server API reference
-- [GOALS.md](./GOALS.md) — Product milestones including M3
-- [SECURITY.md](./SECURITY.md) — Server security posture
+- [DEV.md](./DEV.md) — plugin developer reference (Vault API, crypto module, BRAT distribution).
 
 ### Diagrams
 

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -411,7 +411,7 @@ export default [
 
 ## 7. Silent Stone API Mapping
 
-The plugin communicates with Silent Stone's REST API. See [API_ENDPOINTS.md](./API_ENDPOINTS.md) for full reference.
+The plugin communicates with Silent Stone's REST API. Endpoints are documented in the matching server route handlers in the private `silent-stone` repo.
 
 ### Auth (requires new Bearer token endpoint)
 
@@ -493,16 +493,16 @@ These gaps must be addressed before the plugin is fully functional:
 
 ---
 
-## 9. Crypto Module (`obsidian-plugin/src/crypto/`)
+## 9. Crypto Module (`src/crypto/`)
 
-**Status: v0.3 complete — 14 tests in `obsidian-plugin/src/crypto/__tests__/` (keys.test.ts, cipher.test.ts)**
+**Status: v0.3 complete — 14 tests in `src/crypto/__tests__/` (keys.test.ts, cipher.test.ts)**
 
-The plugin encrypts vault data locally before upload. All crypto lives in `obsidian-plugin/src/crypto/` and is covered by Vitest unit tests in `crypto/__tests__/`.
+The plugin encrypts vault data locally before upload. All crypto lives in `src/crypto/` and is covered by Vitest unit tests in `src/crypto/__tests__/`.
 
 ### File Layout
 
 ```
-obsidian-plugin/src/crypto/
+src/crypto/
 ├── types.ts        # MasterKeyMaterial, WrappedKey, RecoveryPhrase, Argon2Params
 ├── keys.ts         # Key generation, BIP39 recovery, Argon2id password wrapping
 ├── cipher.ts       # AES-256-GCM blob encrypt / decrypt
@@ -598,11 +598,11 @@ Server writes ciphertext to disk. Never sees key or plaintext.
 
 Download path reverses this: `GET /api/vault/blobs/:id` → `decryptBlob()` → write to vault.
 
-**Related:** See `docs/OBSIDIAN_PLUGIN_ARCHITECTURE.md` for the full sync engine design and [`docs/diagrams/sequence-plugin-crypto.md`](./diagrams/sequence-plugin-crypto.md) for a sequence diagram of the encrypt/decrypt flow.
+**Related:** See [`docs/ARCHITECTURE.md`](./ARCHITECTURE.md) for the full sync engine design and [`docs/diagrams/sequence-plugin-crypto.md`](./diagrams/sequence-plugin-crypto.md) for a sequence diagram of the encrypt/decrypt flow.
 
 ---
 
-## 10. VaultClient API Reference (`obsidian-plugin/src/api/vault-client.ts`)
+## 10. VaultClient API Reference (`src/api/vault-client.ts`)
 
 **Status: v0.3 complete — closes #83. 248 lines, typed wrapper around all `/api/vault/*` endpoints.**
 
@@ -725,8 +725,8 @@ Update the Bearer token in place after re-authentication. Useful when a token ex
 
 ### Related Code
 
-- Response types are defined in `obsidian-plugin/src/api/vault-types.ts` (mirrored from `src/lib/vault/schemas.ts` on the server).
-- The matching server handlers live under `src/lib/vault/` (see `docs/API_ENDPOINTS.md` for the full route list).
+- Response types are defined in `src/api/vault-types.ts` (mirrored from server schemas in the private `silent-stone` repo).
+- The matching server handlers live in the private `silent-stone` repo under `src/lib/vault/`.
 - See [`docs/diagrams/sequence-plugin-sync.md`](./diagrams/sequence-plugin-sync.md) for the end-to-end sync sequence that calls these methods.
 
 ---
@@ -739,7 +739,7 @@ The plugin ships to testers via **BRAT** (Beta Reviewers Auto-update Tester) bef
 
 1. Install BRAT in Obsidian: **Settings → Community Plugins → Browse → search "BRAT" → Install → Enable**.
 2. Open BRAT settings: **Settings → Obsidian42 — BRAT → Add Beta Plugin**.
-3. Paste the repo URL: `https://github.com/josemoreno801-netizen/silent-stone`
+3. Paste the repo URL: `https://github.com/josemoreno801-netizen/silent-stone-obsidian`
 4. Click **Add Plugin**. BRAT pulls the latest release.
 5. Enable **Silent Stone Sync** in Community Plugins.
 6. New releases auto-update on Obsidian start. Force a check in BRAT: **Check for updates to all beta plugins**.
@@ -748,7 +748,7 @@ The plugin ships to testers via **BRAT** (Beta Reviewers Auto-update Tester) bef
 
 If BRAT misbehaves or a tester prefers manual control:
 
-1. Download `main.js`, `manifest.json`, `styles.css` from the [latest release](https://github.com/josemoreno801-netizen/silent-stone/releases) — files are at the release root, not zipped.
+1. Download `main.js`, `manifest.json`, `styles.css` from the [latest release](https://github.com/josemoreno801-netizen/silent-stone-obsidian/releases) — files are at the release root, not zipped.
 2. In your Obsidian vault folder, create `.obsidian/plugins/silent-stone-sync/` (the `.obsidian` folder is hidden — enable hidden files in your file manager).
 3. Drop all three files into that directory.
 4. In Obsidian: **Settings → Community Plugins → Reload** (refresh icon), then enable **Silent Stone Sync**.
@@ -759,7 +759,6 @@ If BRAT misbehaves or a tester prefers manual control:
 Releases are fully automated by `.github/workflows/plugin-release.yml`. The workflow fires on any tag matching `plugin-v*`, builds the plugin, and creates a GitHub Release with `main.js`, `manifest.json`, and `styles.css` attached at the release root (which is exactly what BRAT and the registry pattern-match).
 
 ```bash
-cd obsidian-plugin
 npm version patch       # or `minor` / `major`
                         #   - bumps package.json
                         #   - `version` lifecycle hook syncs manifest.json + versions.json
@@ -768,10 +767,10 @@ npm version patch       # or `minor` / `major`
                         #   - `postversion` hook pushes commit + tag
 # Workflow runs automatically. Watch with:
 gh run watch
-gh release view plugin-v0.1.2 --repo josemoreno801-netizen/silent-stone
+gh release view plugin-v0.1.2 --repo josemoreno801-netizen/silent-stone-obsidian
 ```
 
-**If you want to dry-run** (bump locally without pushing): edit `obsidian-plugin/package.json` and temporarily remove the `postversion` script, then re-add after verifying the bump.
+**If you want to dry-run** (bump locally without pushing): edit `package.json` and temporarily remove the `postversion` script, then re-add after verifying the bump.
 
 **If the workflow fails on the version-match check**: the tag and `manifest.json` versions don't agree. Usually means the `version` lifecycle hook didn't run. Fix `manifest.json` manually, force-push the tag (`git tag -f plugin-vX.Y.Z && git push -f origin plugin-vX.Y.Z`), and the workflow re-runs.
 
@@ -780,7 +779,6 @@ gh release view plugin-v0.1.2 --repo josemoreno801-netizen/silent-stone
 For day-to-day plugin development, symlink the build output into an actual Obsidian vault so changes are picked up live by `npm run dev`'s watch mode:
 
 ```bash
-cd obsidian-plugin
 npm install                                    # one-time
 npm run install-to-vault -- /path/to/vault     # creates symlinks in <vault>/.obsidian/plugins/silent-stone-sync/
 npm run dev                                    # watch mode — rebuilds main.js on every save


### PR DESCRIPTION
## Summary

Post-2026-04-20 repo-split staleness in plugin docs. The plugin used to live at `silent-stone/obsidian-plugin/` inside the server repo; after extraction, three classes of breakage leaked through:

- `obsidian-plugin/` path prefixes in DEV.md §§ 9–10 (and elsewhere) that no longer resolve from this repo's root
- Dead cross-references to private server-repo docs (`API_ENDPOINTS.md`, `GOALS.md`, `SECURITY.md`, `OBSIDIAN_PLUGIN_DEV.md`, `OBSIDIAN_PLUGIN_ARCHITECTURE.md`)
- BRAT install instructions in DEV.md §11 still pointing at `github.com/josemoreno801-netizen/silent-stone` (the old monorepo) instead of `silent-stone-obsidian`

## Changes

- **`docs/DEV.md`** (15 line edits): strip `obsidian-plugin/` from §§ 9–10, fix `OBSIDIAN_PLUGIN_ARCHITECTURE.md` → `ARCHITECTURE.md`, drop two inline references to `docs/API_ENDPOINTS.md` (server doc, not in this repo), update three BRAT URLs (`silent-stone` → `silent-stone-obsidian`), drop two `cd obsidian-plugin` lines from code blocks (we're already at repo root), fix `obsidian-plugin/package.json` → `package.json`.
- **`docs/ARCHITECTURE.md`** (2 edits): `obsidian-plugin/CLAUDE.md` → `../CLAUDE.md`. Rewrite "Related Documents" — drop the four broken bullets (server-repo docs unreachable for public readers), keep one bullet pointing at `DEV.md`.
- **`CLAUDE.md`** (1 edit, L87): replace broken `docs/API_ENDPOINTS.md` ref with a pointer to `docs/DEV.md` §§ 7 + 10. The existing "Related Docs" footer already states server API reference lives in the private repo.
- **`docs/diagrams/*.md`**: spot-checked, no changes needed. Mermaid uses unqualified short paths as participant captions, not filesystem links.

## Verification

All three grep gates pass:

```
$ grep -rn "obsidian-plugin/" docs/ CLAUDE.md README.md
(empty)

$ grep -rn -E "OBSIDIAN_PLUGIN_DEV|OBSIDIAN_PLUGIN_ARCHITECTURE|API_ENDPOINTS\.md|GOALS\.md|SECURITY\.md" docs/ CLAUDE.md README.md
(empty)

$ grep -rn "github.com/josemoreno801-netizen/silent-stone[^-]" docs/
(empty)
```

`npm run typecheck` passes. `npm run lint` shows 3 pre-existing warnings in `src/ui/__tests__/setup-modal.test.ts` (untouched by this PR), 0 errors.

## Test plan

- [x] All three doc-rot grep gates return empty
- [x] `npm run typecheck` passes (no source touched)
- [x] `npm run lint` clean of new errors
- [x] Diff stat: 3 files, 16 insertions, 21 deletions — doc-only
- [ ] Reviewer: render DEV.md and ARCHITECTURE.md in the GitHub PR preview, click every internal link, confirm all resolve to a file in this repo

Closes #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)