### PR TITLE
feat(plugin): vault logout — clear persisted token and force re-login

### DIFF
--- a/src/__tests__/settings.test.ts
+++ b/src/__tests__/settings.test.ts
@@ -5,7 +5,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // production code exercises addText, addToggle, addSlider, addDropdown,
 // addButton (with multiple buttons per Setting), setWarning, setTooltip, and
 // setCta. The mock captures every change/click handler so tests can drive them.
-const { MockPluginSettingTab, MockSetting, MockNotice, capturedSettings } = vi.hoisted(
+const {
+  MockPluginSettingTab,
+  MockModal,
+  MockSetting,
+  MockNotice,
+  capturedSettings,
+} = vi.hoisted(
   () => {
     type FakeEl = {
       textContent: string;
@@ -78,6 +84,25 @@ const { MockPluginSettingTab, MockSetting, MockNotice, capturedSettings } = vi.h
       }
       hide(): void {
         // base class no-op; subclass may call super.hide()
+      }
+    }
+
+    // Minimal Modal stub. settings.ts imports LogoutModal which extends
+    // Modal — without this, the obsidian mock fails to satisfy that import.
+    // Tests do not exercise modal behaviour here (covered in logout-modal.test.ts);
+    // we only need the import chain to resolve.
+    class MockModal {
+      app: unknown;
+      contentEl: FakeEl;
+      constructor(app: unknown) {
+        this.app = app;
+        this.contentEl = createFakeEl();
+      }
+      open(): void {
+        (this as unknown as { onOpen?: () => void }).onOpen?.();
+      }
+      close(): void {
+        (this as unknown as { onClose?: () => void }).onClose?.();
       }
     }
 
@@ -170,6 +195,7 @@ const { MockPluginSettingTab, MockSetting, MockNotice, capturedSettings } = vi.h
 
     return {
       MockPluginSettingTab,
+      MockModal,
       MockSetting,
       MockNotice,
       capturedSettings: allSettings,
@@ -179,6 +205,7 @@ const { MockPluginSettingTab, MockSetting, MockNotice, capturedSettings } = vi.h
 
 vi.mock('obsidian', () => ({
   App: class {},
+  Modal: MockModal,
   PluginSettingTab: MockPluginSettingTab,
   Setting: MockSetting,
   Notice: MockNotice,
@@ -331,6 +358,18 @@ describe('SilentStoneSyncSettingTab — Account section', () => {
     await lockBtn!.onClick();
 
     expect(plugin.lockVault).toHaveBeenCalledOnce();
+  });
+
+  it('Log out button is rendered in the Account section', () => {
+    const plugin = makePlugin();
+    openTab(plugin);
+
+    const nicknameRow = findByName('Nickname');
+    const logoutBtn = buttonByLabel(nicknameRow!, 'Log out');
+    // Behaviour (opening LogoutModal, calling logoutVault) is covered by
+    // logout-modal.test.ts. Here we only lock placement: the button must
+    // exist in the Account row alongside Open Dashboard + Lock vault.
+    expect(logoutBtn).toBeDefined();
   });
 
   it('shows nickname in description when signed in', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import { FileWatcher } from './sync/watcher';
 import { SyncEngine } from './sync/engine';
 import { compileIgnorePrefixes, isIgnored } from './sync/ignore';
 import { LoginModal } from './ui/login-modal';
+import { LogoutModal } from './ui/logout-modal';
 import { SetupModal } from './ui/setup-modal';
 import { UnlockModal } from './ui/unlock-modal';
 
@@ -99,6 +100,12 @@ export default class SilentStoneSyncPlugin extends Plugin {
       id: 'vault-lock',
       name: 'Vault: lock (clear in-memory key)',
       callback: () => this.lockVault(),
+    });
+
+    this.addCommand({
+      id: 'vault-logout',
+      name: 'Vault: log out',
+      callback: () => new LogoutModal(this.app, this).open(),
     });
 
     this.addCommand({
@@ -456,6 +463,39 @@ export default class SilentStoneSyncPlugin extends Plugin {
     this.status = 'not-configured';
     this.updateStatusBar();
     new Notice('Vault locked.');
+  }
+
+  /**
+   * Full session exit. Clears the persisted Bearer token so the next plugin reload
+   * routes through LoginModal (a true re-login that mints a fresh token), not
+   * UnlockModal (which assumes the token is still valid).
+   *
+   * Server-side revocation is not available on the Vault track — tokens are
+   * stateless 90-day Bearers that expire naturally.
+   *
+   * Preserves KNOWN_SYNCED_KEY: that's a safety guard against destructive
+   * re-sync, and clearing it belongs to "Switch vault" (issue #9), not logout.
+   */
+  async logoutVault(): Promise<void> {
+    // In-memory teardown — mirrors lockVault, but no Notice (we show our own).
+    if (this.vaultKey) this.vaultKey.fill(0);
+    this.vaultClient = null;
+    this.vaultEngine = null;
+    this.vaultKey = null;
+    this.status = 'not-configured';
+    this.updateStatusBar();
+
+    // Persisted teardown. saveData is a full overwrite (see persistSyncMetrics),
+    // so we read-merge-write to preserve KNOWN_SYNCED_KEY.
+    this.settings.vaultAuthToken = '';
+    this.lastSyncMetrics = {};
+
+    const data = (await this.loadData()) ?? {};
+    Object.assign(data, this.settings);
+    delete data[SYNC_METRICS_KEY];
+    await this.saveData(data);
+
+    new Notice('Logged out. Use "Vault: log in" to reconnect.');
   }
 
   async triggerVaultSync(): Promise<void> {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,7 @@
 import { App, Notice, PluginSettingTab, Setting } from 'obsidian';
 import type SilentStoneSyncPlugin from './main';
 import { SilentStoneClient } from './api/client';
+import { LogoutModal } from './ui/logout-modal';
 
 /**
  * Settings tab for the Silent Stone Sync plugin.
@@ -88,6 +89,15 @@ export class SilentStoneSyncSettingTab extends PluginSettingTab {
           .setWarning()
           .setTooltip('Clear the in-memory key. Re-unlock with your password to resume sync.')
           .onClick(() => this.plugin.lockVault()),
+      )
+      .addButton((btn) =>
+        btn
+          .setButtonText('Log out')
+          .setWarning()
+          .setTooltip(
+            "Sign out and clear your saved connection. You'll need your password and nickname to reconnect.",
+          )
+          .onClick(() => new LogoutModal(this.plugin.app, this.plugin).open()),
       );
   }
 

--- a/src/ui/__tests__/logout-modal.test.ts
+++ b/src/ui/__tests__/logout-modal.test.ts
@@ -1,0 +1,334 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mock `obsidian` ────────────────────────────────
+// vitest runs in node (no jsdom). We hand-roll the minimum DOM surface the
+// LogoutModal touches: createEl/empty for content tree, a chainable Setting
+// that captures button handlers, and a Modal base whose close() invokes the
+// subclass's onClose hook so the cleanup contract is testable.
+const {
+  MockModal,
+  MockSetting,
+  MockNotice,
+  lastSettingHandlers,
+  resetHandlers,
+} = vi.hoisted(() => {
+  type FakeButtonEl = {
+    disabled: boolean;
+    textContent: string;
+  };
+
+  type ButtonHandler = {
+    onClick?: () => void | Promise<void>;
+    buttonEl: FakeButtonEl;
+    setButtonTextCalls: string[];
+    setWarningCalls: number;
+  };
+
+  type Handlers = {
+    buttonHandlers: ButtonHandler[];
+  };
+
+  type FakeEl = {
+    tagName: string;
+    textContent: string;
+    children: FakeEl[];
+    cls: string[];
+    createEl: (
+      tag: string,
+      opts?: { text?: string; cls?: string },
+    ) => FakeEl;
+    empty: () => void;
+  };
+
+  const allSettings: Handlers[] = [];
+
+  function createFakeEl(tag: string): FakeEl {
+    const el: FakeEl = {
+      tagName: tag.toUpperCase(),
+      textContent: '',
+      children: [],
+      cls: [],
+      createEl: (t, opts) => {
+        const child = createFakeEl(t);
+        if (opts?.text) child.textContent = opts.text;
+        if (opts?.cls) child.cls.push(...opts.cls.split(/\s+/));
+        el.children.push(child);
+        return child;
+      },
+      empty: () => {
+        el.children = [];
+        el.textContent = '';
+      },
+    };
+    return el;
+  }
+
+  class MockModal {
+    app: unknown;
+    contentEl: FakeEl;
+    close: () => void;
+
+    constructor(app: unknown) {
+      this.app = app;
+      this.contentEl = createFakeEl('div');
+      this.close = vi.fn(() => {
+        (this as unknown as { onClose?: () => void }).onClose?.();
+      });
+    }
+
+    open(): void {
+      (this as unknown as { onOpen?: () => void }).onOpen?.();
+    }
+  }
+
+  type ButtonApi = {
+    setButtonText: (t: string) => ButtonApi;
+    setWarning: () => ButtonApi;
+    setCta: () => ButtonApi;
+    setTooltip: (t: string) => ButtonApi;
+    onClick: (fn: () => void | Promise<void>) => ButtonApi;
+    buttonEl: FakeButtonEl;
+  };
+
+  class MockSetting {
+    private handlers: Handlers;
+
+    constructor(_parent: unknown) {
+      this.handlers = { buttonHandlers: [] };
+      allSettings.push(this.handlers);
+    }
+
+    setName(_name: string): this {
+      return this;
+    }
+
+    setDesc(_desc: string): this {
+      return this;
+    }
+
+    addButton(cb: (b: ButtonApi) => void): this {
+      const buttonEl: FakeButtonEl = { disabled: false, textContent: '' };
+      const captured: ButtonHandler = {
+        buttonEl,
+        setButtonTextCalls: [],
+        setWarningCalls: 0,
+      };
+      const api: ButtonApi = {
+        setButtonText: (t: string) => {
+          captured.setButtonTextCalls.push(t);
+          buttonEl.textContent = t;
+          return api;
+        },
+        setWarning: () => {
+          captured.setWarningCalls += 1;
+          return api;
+        },
+        setCta: () => api,
+        setTooltip: (_t: string) => api,
+        onClick: (fn: () => void | Promise<void>) => {
+          captured.onClick = fn;
+          return api;
+        },
+        buttonEl,
+      };
+      cb(api);
+      this.handlers.buttonHandlers.push(captured);
+      return this;
+    }
+  }
+
+  function lastSettingHandlers(): Handlers[] {
+    return allSettings;
+  }
+
+  function resetHandlers(): void {
+    allSettings.length = 0;
+  }
+
+  const MockNotice = vi.fn();
+
+  return {
+    MockModal,
+    MockSetting,
+    MockNotice,
+    lastSettingHandlers,
+    resetHandlers,
+  };
+});
+
+vi.mock('obsidian', () => ({
+  App: class {},
+  Modal: MockModal,
+  Setting: MockSetting,
+  Notice: MockNotice,
+}));
+
+import { LogoutModal } from '../logout-modal';
+
+// ── Test helpers ───────────────────────────────────
+type FakePlugin = {
+  app: unknown;
+  logoutVault: ReturnType<typeof vi.fn>;
+};
+
+function makeFakePlugin(overrides: Partial<FakePlugin> = {}): FakePlugin {
+  return {
+    app: {},
+    logoutVault: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+type TreeNode = { textContent: string; children: TreeNode[] };
+
+function findByText(node: TreeNode, needle: string): boolean {
+  if ((node.textContent ?? '').includes(needle)) return true;
+  for (const c of node.children ?? []) {
+    if (findByText(c, needle)) return true;
+  }
+  return false;
+}
+
+function findButton(label: string): {
+  onClick?: () => void | Promise<void>;
+  buttonEl: { disabled: boolean; textContent: string };
+  setWarningCalls: number;
+} | undefined {
+  for (const s of lastSettingHandlers()) {
+    for (const b of s.buttonHandlers) {
+      if (b.setButtonTextCalls.includes(label)) return b;
+    }
+  }
+  return undefined;
+}
+
+beforeEach(() => {
+  resetHandlers();
+  MockNotice.mockReset();
+});
+
+describe('LogoutModal', () => {
+  it('renders title + copy explaining what logout does and does not affect', () => {
+    const plugin = makeFakePlugin();
+    const modal = new LogoutModal(plugin.app as never, plugin as never);
+    modal.open();
+
+    const root = modal.contentEl as unknown as TreeNode;
+    expect(findByText(root, 'Log out of Silent Stone')).toBe(true);
+    expect(findByText(root, 'connection token')).toBe(true);
+    // Reassures the user that logout doesn't wipe their notes — important
+    // because the action is destructive-adjacent and the warning styling
+    // could otherwise read as "delete vault."
+    expect(findByText(root, 'local notes are not affected')).toBe(true);
+  });
+
+  it('Log out button is rendered with warning styling', () => {
+    const plugin = makeFakePlugin();
+    const modal = new LogoutModal(plugin.app as never, plugin as never);
+    modal.open();
+
+    const logoutBtn = findButton('Log out');
+    expect(logoutBtn).toBeDefined();
+    expect(logoutBtn!.setWarningCalls).toBe(1);
+  });
+
+  it('Cancel closes the modal without calling logoutVault', async () => {
+    const plugin = makeFakePlugin();
+    const modal = new LogoutModal(plugin.app as never, plugin as never);
+    const closeSpy = vi.spyOn(modal, 'close');
+    modal.open();
+
+    const cancelBtn = findButton('Cancel');
+    expect(cancelBtn).toBeDefined();
+    await cancelBtn?.onClick?.();
+
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    expect(plugin.logoutVault).not.toHaveBeenCalled();
+  });
+
+  it('Log out invokes plugin.logoutVault and closes the modal', async () => {
+    const plugin = makeFakePlugin();
+    const modal = new LogoutModal(plugin.app as never, plugin as never);
+    const closeSpy = vi.spyOn(modal, 'close');
+    modal.open();
+
+    const logoutBtn = findButton('Log out');
+    expect(logoutBtn).toBeDefined();
+    logoutBtn?.onClick?.();
+    // Drain the microtask queue: submit() awaits logoutVault, then close.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(plugin.logoutVault).toHaveBeenCalledTimes(1);
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the Log out button while the logout request is in flight', async () => {
+    let resolveLogout!: () => void;
+    const inflight = new Promise<void>((resolve) => {
+      resolveLogout = resolve;
+    });
+    const plugin = makeFakePlugin({
+      logoutVault: vi.fn().mockReturnValue(inflight),
+    });
+    const modal = new LogoutModal(plugin.app as never, plugin as never);
+    modal.open();
+
+    const logoutBtn = findButton('Log out');
+    expect(logoutBtn).toBeDefined();
+
+    // Fire — submit() runs synchronously up to its first await, which is
+    // where it sets the disabled flag and the spinner copy.
+    logoutBtn?.onClick?.();
+    expect(logoutBtn!.buttonEl.disabled).toBe(true);
+    expect(logoutBtn!.buttonEl.textContent).toBe('Logging out…');
+
+    // Resolve and let the finally block reset state.
+    resolveLogout();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(plugin.logoutVault).toHaveBeenCalledTimes(1);
+    expect(logoutBtn!.buttonEl.disabled).toBe(false);
+    expect(logoutBtn!.buttonEl.textContent).toBe('Log out');
+  });
+
+  it('rejects double-submission while a logout is in flight', async () => {
+    let resolveLogout!: () => void;
+    const inflight = new Promise<void>((resolve) => {
+      resolveLogout = resolve;
+    });
+    const plugin = makeFakePlugin({
+      logoutVault: vi.fn().mockReturnValue(inflight),
+    });
+    const modal = new LogoutModal(plugin.app as never, plugin as never);
+    modal.open();
+
+    const logoutBtn = findButton('Log out');
+    expect(logoutBtn).toBeDefined();
+
+    logoutBtn?.onClick?.();
+    logoutBtn?.onClick?.();
+    logoutBtn?.onClick?.();
+
+    resolveLogout();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // All extra clicks short-circuit on `if (this.submitting) return;`
+    expect(plugin.logoutVault).toHaveBeenCalledTimes(1);
+  });
+
+  it('onClose empties contentEl', () => {
+    const plugin = makeFakePlugin();
+    const modal = new LogoutModal(plugin.app as never, plugin as never);
+    modal.open();
+    expect(modal.contentEl.children.length).toBeGreaterThan(0);
+
+    modal.onClose();
+    expect(modal.contentEl.children.length).toBe(0);
+  });
+});

--- a/src/ui/logout-modal.ts
+++ b/src/ui/logout-modal.ts
@@ -1,0 +1,62 @@
+import { App, Modal, Setting } from 'obsidian';
+import type SilentStoneSyncPlugin from '../main';
+
+export class LogoutModal extends Modal {
+  private plugin: SilentStoneSyncPlugin;
+  private submitting = false;
+  private confirmBtn: HTMLButtonElement | null = null;
+
+  constructor(app: App, plugin: SilentStoneSyncPlugin) {
+    super(app);
+    this.plugin = plugin;
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+
+    contentEl.createEl('h2', { text: 'Log out of Silent Stone' });
+    contentEl.createEl('p', {
+      text:
+        "This clears your saved connection token. You'll need your nickname and password to reconnect.",
+      cls: 'setting-item-description',
+    });
+    contentEl.createEl('p', {
+      text: 'Your local notes are not affected — only the connection to the server is cleared.',
+      cls: 'setting-item-description',
+    });
+
+    new Setting(contentEl)
+      .addButton((btn) => btn.setButtonText('Cancel').onClick(() => this.close()))
+      .addButton((btn) => {
+        btn
+          .setButtonText('Log out')
+          .setWarning()
+          .onClick(() => void this.submit());
+        this.confirmBtn = btn.buttonEl;
+      });
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+
+  private async submit(): Promise<void> {
+    if (this.submitting) return;
+    this.submitting = true;
+    if (this.confirmBtn) {
+      this.confirmBtn.disabled = true;
+      this.confirmBtn.textContent = 'Logging out…';
+    }
+    try {
+      await this.plugin.logoutVault();
+      this.close();
+    } finally {
+      this.submitting = false;
+      if (this.confirmBtn) {
+        this.confirmBtn.disabled = false;
+        this.confirmBtn.textContent = 'Log out';
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

User reported they couldn't log out of the plugin. They were right — the plugin had **Lock** but no **Logout**, which meant locked state auto-reconnects on every reload. This adds a real session exit.

### Why Lock isn't Logout

| | In-memory key cleared? | Persisted Bearer token cleared? | Next reload pops |
|---|:-:|:-:|---|
| **Lock** (existing) | yes | **no** | UnlockModal (password unwraps stored token) |
| **Logout** (this PR) | yes | **yes** | LoginModal (full re-login mints new 90-day token) |

The rehydration logic at `src/main.ts:132-147` already routed correctly based on whether `settings.vaultAuthToken` is set — clearing it in logout is what flips the route from UnlockModal to LoginModal on the next reload.

### State teardown

- **in-memory**: `vaultKey` (zeroed via `.fill(0)` before nulling), `vaultClient`, `vaultEngine`, `status` → `not-configured`
- **persisted (cleared)**: `settings.vaultAuthToken`, `lastSyncMetrics` + `SYNC_METRICS_KEY`
- **persisted (kept)**: `KNOWN_SYNCED_KEY` — sync safety guard; full local reset is "Switch vault" territory tracked in #9
- **server-side**: no revocation endpoint on the Vault track; tokens expire naturally at 90 days. Logout is necessarily client-only

### Why a custom save path instead of `saveSettings()`

`saveSettings()` does `await this.saveData(this.settings)` — a full overwrite that wipes sibling keys. `persistSyncMetrics` already works around this with a read-merge-write. `logoutVault()` uses the same pattern so `KNOWN_SYNCED_KEY` survives.

### Surfaces

- Command palette: `Vault: log out`
- Settings → Account: warning-styled `Log out` button next to `Lock vault`
- Confirmation modal mirroring `unlock-modal.ts` (single-step, Cancel + warning-styled action, in-flight disable + spinner copy, double-click guard)

## Test plan

- [x] `npx tsc --noEmit` — no `src/` errors
- [x] `npm run lint` — 3 baseline warnings only (pre-existing in `setup-modal.test.ts`); 0 errors; no new warnings introduced
- [x] `npm test` — 210/210 pass (7 new in `logout-modal.test.ts`, 1 new in `settings.test.ts`; settings suite was failing prior to a Modal stub being added to its `obsidian` mock — fix included)
- [x] `npm run build` — clean
- [ ] Manual end-to-end in a real vault (`npm run install-to-vault -- <vault>`):
  - [ ] Settings → Account → `Log out` opens confirmation modal
  - [ ] Cancel closes without state change
  - [ ] Log out → notice fires, status bar reads `not-configured`
  - [ ] **Reload Obsidian** → `LoginModal` auto-pops (NOT `UnlockModal`) — decisive proof the persisted token was cleared
  - [ ] Log in fresh → new Bearer token mints, sync resumes

## Out of scope (parked)

- Server-side token revocation — needs a new Vault API endpoint
- Switch vault / disconnect entirely (clears `KNOWN_SYNCED_KEY` + all sync state) — tracked in #9
- `.gitignore` += `.DS_Store` + CLAUDE.md lint baseline note — separate trailing PR
- PR #30 — independent (different files); both can merge in either order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Implements a full logout flow for the Vault plugin that clears persisted authentication state and forces complete re-authentication on next reload. Distinguishes between Lock (in-memory teardown only) and Logout (full state wipe).

## Changes
**UI/UX:**
- New `LogoutModal` component with confirmation flow, in-flight disable, loading indicator, and double-submission guard
- "Log out" button added to Settings → Account with warning styling and descriptive tooltip
- "Vault: log out" command palette entry wired to trigger logout flow

**Core Logic:**
- `logoutVault()` method performs tactical state teardown:
  - **In-memory:** zeroes/nulls vaultKey, clears vaultClient and vaultEngine, sets status to not-configured
  - **Persisted (cleared):** settings.vaultAuthToken, lastSyncMetrics, SYNC_METRICS_KEY
  - **Persisted (preserved):** KNOWN_SYNCED_KEY (sync safety guard)
- Uses read-merge-write pattern to avoid collateral damage to sibling persisted keys
- Updates status bar and surfaces logout completion notice
- Server-side: no token revocation (90-day expiry is hardened client-side)

**Testing:**
- New LogoutModal test suite (7 tests) validates: modal content, button states, cancel behavior, submit flow, in-flight disable/spinner, double-submission prevention, cleanup
- New settings test confirms Log out button presence
- MockModal stub added to obsidian mocks for test chain resolution
- TypeScript build and lint pass; 210/210 unit tests pass

## Architecture Note
Rehydration logic at src/main.ts routes to UnlockModal if settings.vaultAuthToken exists, LoginModal if absent—logout enables forced re-login by clearing that key.

## Out of Scope
Manual E2E verification not yet completed; documented in PR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->