### PR TITLE
feat(plugin): wire ADR-004 integration into field commands (LOC-50)

### DIFF
--- a/.claude/commands/ss-mission-status.md
+++ b/.claude/commands/ss-mission-status.md
@@ -1,16 +1,37 @@
 ---
-description: Show where this repo's active mission stands — sub-issue checklist with [x]/[~]/[ ] markers and a one-line verdict
+description: Show where this repo's active mission stands — runs a lazy mission-parent rollup first, then prints the sub-issue checklist with [x]/[~]/[ ] markers and a one-line verdict
 ---
 
 # /ss-mission-status — where the field session stands
 
-You are in the **plugin field session** (`silent-stone-obsidian`). This command prints a read-only checklist of the active mission's sub-issues so the operator knows what's done, what's in flight, and what's left.
+You are in the **plugin field session** (`silent-stone-obsidian`). This command prints a checklist of the active mission's sub-issues so the operator knows what's done, what's in flight, and what's left. Before rendering, it runs a **lazy mission-parent rollup pass**: if any in-flight mission has all sub-issues Done but the parent isn't yet, this command flips the parent Done — covering the gap that the ADR-004 integration doesn't (the integration auto-closes leaf tickets, not parents).
 
-**Read-only. No Linear writes. No git mutations.** Low-risk; usable by the model on its own initiative too (no `disable-model-invocation` flag).
+**One bounded Linear write only** — the rollup. Everything else is read-only. No git mutations. Usable by the model on its own initiative (no `disable-model-invocation` flag) because the rollup write is gated on "all children Done" — it never closes a parent that has open work.
 
 **Scope:** plugin project only — `silent-stone-obsidian (plugin)` / project id `90f7de75-e92b-4287-84f0-0d5b703d9730` / team `LOCAL-DAILY` / key `LOC`.
 
 ## Steps
+
+### 0. Lazy mission-parent rollup pass
+
+Before rendering anything, check whether any in-flight mission needs to be closed:
+
+```
+list_issues(team: "LOCAL-DAILY", project: "silent-stone-obsidian (plugin)", query: "Mission:", state: "In Progress")
+```
+
+Filter to titles starting with `Mission:`. For each parent:
+
+- `list_issues(parentId: <parent.id>)` → all sub-issues + states.
+- If EVERY sub-issue has `state.type === "completed"` AND the parent itself is `state.type !== "completed"`:
+  - `save_issue(id: <parent.id>, state: "Done")`
+  - Immediately verify: `get_issue(<parent.id>)` — confirm `state.type === "completed"`.
+  - If verify fails, **surface the discrepancy loudly**. Linear MCP silent-failure landmine.
+  - Print: `Mission rolled up: <parent.title> — <parent.url>`
+
+If no parent needs rollup, this step is silent — no output. Continue to step 1.
+
+This is the ONLY Linear write this command makes. It is bounded — fires only when the integration has already flipped every child Done.
 
 ### 1. Find the active mission parent for THIS repo
 
@@ -51,8 +72,8 @@ Sort sub-issues by priority (Urgent first), then by ticket ID ascending when pri
 
 Pick the first matching condition:
 
-- **All sub-issues Done** → `Mission ready to close. /ss-ship the last one already.`  
-  *(If you see this state, something's odd — `/ss-ship` should have auto-closed the parent when the last sub-issue shipped. Surface it.)*
+- **All sub-issues Done** → `All sub-issues Done but parent still In Progress. Step 0's rollup didn't fire — Linear write may have failed. Investigate or manually flip the parent.`  
+  *(In normal flow this branch is unreachable: step 0 would have closed the parent, and step 1's filter would exclude already-closed missions. Reaching here implies an MCP write failure earlier in the same run.)*
 - **One sub-issue In Progress, the rest Done** → `<N-1> of <N> shipped. Finish LOC-NN to close the mission.`
 - **One sub-issue In Progress, others Backlog** → `LOC-NN in flight. /ss-ship when ready, then /ss-pull next.`
 - **All Backlog, none In Progress** → `Nothing claimed yet. /ss-pull to start.`
@@ -68,6 +89,7 @@ End. No closing fluff.
 
 ## Anti-patterns (never do)
 
-- **Writing to Linear.** This command is read-only. If the operator wants to act on what they see, they invoke `/ss-pull` or `/ss-ship`.
+- **Writing to Linear outside the bounded rollup in step 0.** The rollup fires only when EVERY sub-issue is already Done. Don't expand the write surface — no flipping leaf tickets here (that's the integration's job via `/ss-ship`), no flipping In Progress missions, nothing else.
 - **Crossing repos.** Plugin field session shows the plugin mission only. Web mission status lives in `silent-stone/.claude/commands/ss-mission-status.md`.
 - **Padding verdicts.** Pick one condition and print it. Don't append "consider also…" — the verdict carries the read.
+- **Skipping step 0.** The lazy rollup is the whole reason this command coexists with `/ss-pull`'s rollup — multiple entry points ensure the parent eventually closes. Don't optimize the rollup away if "the operator usually does it via /ss-pull anyway."

--- a/.claude/commands/ss-pull.md
+++ b/.claude/commands/ss-pull.md
@@ -1,57 +1,102 @@
 ---
-description: Claim the next sub-issue from this repo's active mission — flips it to In Progress in Linear and prints the git checkout line
+description: Claim the next sub-issue from this repo's active mission — sweep stale worktrees, roll up done missions lazily, then spawn a fresh worktree + tmux window with the ticket briefing
 disable-model-invocation: true
 ---
 
-# /ss-pull — claim the next sub-issue
+# /ss-pull — claim next sub-issue into a worktree session
 
-You are in the **plugin field session** (`silent-stone-obsidian`). HQ planned a mission as a Linear parent issue with reparented sub-issues. This command claims the next one for you to work on.
+You are in the **plugin field session** (`silent-stone-obsidian`). HQ planned a mission as a Linear parent issue with reparented sub-issues. This command:
+
+1. Sweeps any stale `.claude/worktrees/loc-*` from previously-shipped tickets.
+2. Lazily rolls up any mission parent whose sub-issues are all Done.
+3. Enforces WIP-1 by checking active worktrees, not Linear state.
+4. Claims the next `Backlog` sub-issue.
+5. Spawns a fresh git worktree + tmux window for it, briefed via `WORKTREE_PROMPT.md`.
 
 **Scope:** plugin project only — `silent-stone-obsidian (plugin)` / project id `90f7de75-e92b-4287-84f0-0d5b703d9730` / team `LOCAL-DAILY` / key `LOC`.
 
-This command writes to Linear (one state transition). It is user-invoked only.
+This command **does not write to Linear for the leaf ticket.** The ADR-004 Linear↔GitHub integration (Approach B) flips the leaf Backlog → In Progress when the worktree's PR is opened by `/ss-ship`. The only Linear write this command can make is the lazy mission-parent close in step 2 (if applicable).
 
 ## Steps
 
-### 1. Find the active mission parent for THIS repo
+### 1. Stale-worktree sweep
 
-- `list_issues(team: "LOCAL-DAILY", project: "silent-stone-obsidian (plugin)", query: "Mission:", state: "In Progress")`
-- Filter results to titles that start with `Mission:` (the `query` field is broad search, not prefix match).
-- For each candidate, run `list_issues(parentId: <id>)` and check if **at least one sub-issue is not Done**. Keep the one(s) that have open work.
-
-**If zero active missions:** stop. Print:
-```
-No active plugin mission. Run /ss-mission at HQ first.
+```bash
+git worktree list --porcelain
 ```
 
-**If multiple active missions:** stop. Print all of them with URLs and tell the user to close one before pulling — discipline check.
+For every worktree at `<repo-root>/.claude/worktrees/loc-NN-<slug>`:
 
-### 2. Pick the next sub-issue
+- Parse `loc-NN` → `LOC-NN`.
+- `get_issue("LOC-NN")` → check `state.type`.
+- `git branch --merged main` → check if `josemoreno801/loc-NN-<slug>` is in the list.
+
+If BOTH `state.type === "completed"` AND the branch is merged into main, sweep:
+
+```bash
+git worktree remove --force ".claude/worktrees/loc-NN-<slug>"
+git branch -D josemoreno801/loc-NN-<slug>
+```
+
+If only ONE is true (Linear Done but branch unmerged, or branch merged but Linear still In Progress), **do not sweep**. Print a one-line warning:
+
+```
+Stale-but-inconsistent worktree: <path>. Linear=<state>, branch merged=<bool>. Leaving in place.
+```
+
+This is a soldier check — when the two systems disagree, surface it instead of silently picking one.
+
+### 2. Lazy mission-parent rollup
+
+```
+list_issues(team: "LOCAL-DAILY", project: "silent-stone-obsidian (plugin)", query: "Mission:", state: "In Progress")
+```
+
+Filter to titles starting with `Mission:`. For each parent:
+
+- `list_issues(parentId: <parent.id>)` → all sub-issues + states.
+- If EVERY sub-issue has `state.type === "completed"` AND the parent itself is `state.type !== "completed"`:
+  - `save_issue(id: <parent.id>, state: "Done")`
+  - Immediately verify: `get_issue(<parent.id>)` — confirm `state.type === "completed"`.
+  - If verify fails, **surface the discrepancy loudly**. Linear MCP silent-failure landmine.
+  - Print: `Mission rolled up: <parent.title> — <parent.url>`
+
+This is the ONLY Linear write this command makes. It is intentional — the integration doesn't auto-close parents, so we do it lazily here.
+
+### 3. WIP-1 enforcement via worktrees
+
+After the sweep (step 1), count remaining `.claude/worktrees/loc-*` directories. If ≥ 1 active worktree exists, **stop**:
+
+```
+WIP-1 breach — active worktree at <path>. Finish or sweep it before pulling another.
+Run /ss-ship in that worktree, or sweep manually if you abandoned the work.
+```
+
+The discipline is enforced at the file-system level, not Linear. A leaf ticket can be Backlog (per integration timing) but its worktree still represents active work.
+
+### 4. Find the active mission parent
+
+```
+list_issues(team: "LOCAL-DAILY", project: "silent-stone-obsidian (plugin)", query: "Mission:", state: "In Progress")
+```
+
+Filter to titles starting with `Mission:` (broad search, not prefix match). For each candidate, run `list_issues(parentId: <id>)` and keep only those with **at least one sub-issue not Done**.
+
+- **Zero active missions:** stop. Print `No active plugin mission. Run /ss-mission at HQ first.`
+- **Multiple active missions:** stop. Print all candidates with URLs. Tell the operator to close one before pulling — discipline check.
+
+### 5. Pick the next sub-issue
 
 - `list_issues(parentId: <mission-id>)` → all sub-issues with priority + state.
-- Filter to state `Backlog` (skip In Progress and Done).
-- Sort by priority (`Urgent` > `High` > `Medium` > `Low` > `None`), then by ticket ID ascending (older / lower-numbered first when priorities tie).
+- Filter to `state.type === "unstarted"` (Backlog). Skip In Progress and Done.
+- Sort by priority (`Urgent` > `High` > `Medium` > `Low` > `None`), then ticket ID ascending.
 - Take the first.
 
-**If zero `Backlog` sub-issues:**
-- If any sub-issue is still `In Progress`, print: `Already in flight: LOC-NN. Finish or unblock that one before pulling another.`
-- If all are `Done`, print: `Mission complete — close it with /ss-ship on the last sub-issue, or run /ss-mission-status.` Stop.
+**If zero Backlog sub-issues:**
+- If any sub-issue is still `In Progress` (in flight via integration), print `Already in flight: LOC-NN. Wait for its PR to merge, then pull again.` Stop.
+- If all are Done, print `Mission complete — run /ss-mission-status to roll it up.` Stop.
 
-### 3. Flip the sub-issue to In Progress
-
-```
-save_issue(id: "LOC-NN", state: "In Progress")
-```
-
-Immediately verify:
-
-```
-get_issue("LOC-NN")
-```
-
-Confirm `state.name === "In Progress"`. If not, **stop and surface the discrepancy** — this is the documented Linear MCP silent-failure landmine. Don't print the branch line for a ticket that didn't actually transition.
-
-### 4. Echo the mission briefing
+### 6. Echo the mission briefing
 
 Read the parent's description (`get_issue(<mission-id>)` → `description`). Print it back so the operator re-anchors on the batch's intent before opening files.
 
@@ -61,40 +106,109 @@ Read the parent's description (`get_issue(<mission-id>)` → `description`). Pri
 <parent.description>
 ```
 
-### 5. Print the branch line + ticket card
+### 7. `$TMUX` guard
 
-Use the ticket's `gitBranchName` field (Linear provides it — e.g. `josemoreno801/loc-12-implement-conflict-resolution-modal`).
+```bash
+[ -z "$TMUX" ]
+```
+
+If the env var is unset → stop. Print:
+
+```
+/ss-pull requires you to be running inside a tmux session.
+Spawn one with `tmux new -s plugin-dd` and re-run.
+```
+
+No fallback. Option A safety — hard-fail per ADR-004 implementation plan.
+
+### 8. Create the worktree
+
+Use the ticket's `gitBranchName` from Linear (e.g. `josemoreno801/loc-12-implement-conflict-resolution-modal`). If Linear returns null, fall back to `josemoreno801/loc-NN-<slugified-title>` and print a warning.
+
+```bash
+git worktree add ".claude/worktrees/loc-NN-<slug>" -b "<ticket.gitBranchName>" origin/main
+```
+
+Run from the repo root. The path is relative; the branch is created off origin/main (not local main — origin is the source of truth).
+
+If `git worktree add` fails (path already exists, branch already exists), **stop**. Don't force. The stale-worktree sweep in step 1 should have prevented this — if it didn't, something is wrong; investigate manually.
+
+### 9. Write `WORKTREE_PROMPT.md` to the worktree root
+
+Compute the absolute worktree path: `<repo-root>/.claude/worktrees/loc-NN-<slug>`.
+
+Write a file at `<worktree-path>/WORKTREE_PROMPT.md` with this content (substitute the real ticket data):
 
 ```markdown
-**Claimed:** LOC-NN — <title>
-Priority: <priority>
-Linear: <ticket.url>
+# Worktree session — LOC-NN
 
-Run this when you're ready:
+You are in the plugin worktree for `LOC-NN — <ticket.title>`.
+
+**Linear:** <ticket.url>
+**Parent mission:** <parent.title> — <parent.url>
+**Branch:** <ticket.gitBranchName>
+
+## Ticket body
+
+<ticket.description>
+
+## Your move
+
+1. Read the ticket body above. Re-anchor on intent.
+2. Implement the change. Run tests as you go: `npm test`, `npm run typecheck`, `npm run lint`.
+3. When done, run `/ss-ship` to commit + push + open PR. The Linear↔GitHub integration flips LOC-NN to Done when the PR merges. Do NOT manually flip Linear from this session.
+
+Soldier-mode is on. The play is in front of you. Move.
 ```
+
+The CLAUDE.md auto-load convention (see project root) tells the spawned claude session to read this file on session start, execute its contents as the initial prompt, then delete it.
+
+### 10. Spawn the tmux window
+
 ```bash
-git checkout -b <ticket.gitBranchName>
-```
+tmux new-window -n "loc-NN" -c "<absolute-worktree-path>" "claude --debug"
 ```
 
-**Do not auto-execute the `git checkout`.** Print only. The operator runs it.
+- `-n` names the window (e.g. `loc-12`) so the operator can swap to it with `Ctrl-b N` or `Ctrl-b ,`.
+- `-c` sets the window's working directory to the worktree's absolute path. **Absolute, not relative** — `tmux new-window -c` breaks on relative.
+- The trailing command is `claude --debug` — debug mode hardcoded per ADR-004 implementation plan.
 
-End. No closing fluff.
+If `tmux new-window` fails (no `$TMUX`, but you should have caught that in step 7), print the error and stop. The worktree and `WORKTREE_PROMPT.md` are already created — the operator can `cd` and `claude --debug` manually as a fallback.
+
+### 11. Final output
+
+```
+Claimed: LOC-NN — <ticket.title>
+Priority: <ticket.priority>
+Linear:   <ticket.url>
+Worktree: <absolute-worktree-path>
+Branch:   <ticket.gitBranchName>
+
+Spawned tmux window "loc-NN". Swap with Ctrl-b N or Ctrl-b ,.
+Linear stays Backlog until the PR opens — the integration flips it then.
+```
+
+End.
 
 ## Output discipline
 
-- Never invent a `gitBranchName`. If Linear returns null for some reason, fall back to the format `josemoreno801/loc-NN-<slugified-title>` and call it out as a fallback so the operator can fix it on Linear's end.
-- If `get_issue` returns a different `parent.id` than the active mission you found in step 1, **stop**. Something reparented the ticket out from under you mid-command.
+- Never invent a `gitBranchName`. If Linear returns null, fall back and call it out as a warning.
+- If `get_issue` returns a different `parent.id` than the active mission you found in step 4, stop — something reparented mid-command.
+- Always print the absolute worktree path so the operator can `cd` to it manually if needed.
 
 ## Anti-patterns (never do)
 
-- **Auto-running `git checkout`.** Print only.
-- **Pulling a sub-issue from a different repo's mission.** This command is plugin-scoped. The web equivalent lives in `silent-stone/.claude/commands/ss-pull.md`.
-- **Pulling while another sub-issue is In Progress.** WIP-1 discipline at the mission level. Finish the current one (via `/ss-ship`) first.
-- **Skipping the `get_issue` verify** after the state transition. Linear MCP writes can lie.
+- **Writing the leaf ticket to In Progress here.** The integration handles that on PR open. Manual writes from this command bring back the race condition we eliminated.
+- **Skipping the stale-worktree sweep.** If you leave dead worktrees in place, WIP-1 stops working.
+- **Skipping the lazy mission-parent rollup.** The integration doesn't close parents; if `/ss-pull` doesn't roll them up, nothing will.
+- **Pulling without an active tmux session.** Hard-fail. Print the spawn instruction and stop.
+- **Force-flipping the WIP-1 check.** If a worktree is in flight, finish it (`/ss-ship` inside the worktree) or sweep it manually. Don't override.
+- **Auto-`cd`-ing the operator's main session into the worktree.** Spawn the tmux window instead. The operator's main session stays where it is.
 
-## What this command does NOT do
+## Landmines
 
-- Run `git checkout` for you.
-- Open files. The operator drives implementation; this command just hands off.
-- Touch any ticket not in the active mission. One-off tickets are handled directly via `/ss-ship` after the operator picks them manually.
+1. `list_issues` `state` parameter expects the state NAME (e.g. `"In Progress"`), not `state.type`. Don't pass `"started"`.
+2. `git worktree add` with `-b` creates the branch from the `<commit-ish>` argument (here, `origin/main`). If you accidentally pass `main` (local), you may branch off a stale or divergent commit. Use `origin/main` explicitly.
+3. `tmux new-window` runs the command in the operator's shell context (zsh/bash), so the working directory `-c` must be a real path the shell can `cd` into. Absolute path only.
+4. The `WORKTREE_PROMPT.md` file is auto-deleted by the spawned session per CLAUDE.md convention. Don't write it expecting it to persist — it's transient.
+5. If the operator runs `/ss-pull` from inside an existing worktree session (not the main session), step 7's `$TMUX` guard will pass but the spawn will create a window in whatever tmux session they're in, not the main session. That's usually fine, but worth knowing.

--- a/.claude/commands/ss-ship.md
+++ b/.claude/commands/ss-ship.md
@@ -1,19 +1,21 @@
 ---
-description: Ship the ticket on the current branch — commit, flip Linear to Done, and (if mission sub-issue) report mission progress or close the mission
+description: Ship the ticket on the current branch — commit, push, open PR. Integration auto-flips Linear on PR open/merge.
 disable-model-invocation: true
 ---
 
-# /ss-ship — close the current ticket
+# /ss-ship — commit + push + PR for the current ticket
 
-You are in the **plugin field session** (`silent-stone-obsidian`). The operator finished work on a ticket and wants to commit + close it. This command handles both **mission sub-issues** (the common case) and **one-off tickets** (when the operator works outside a mission).
+You are in the **plugin field session** (`silent-stone-obsidian`). The operator finished work on a ticket and wants to commit + push + open a PR. This command handles both **mission sub-issues** (the common case) and **one-off tickets** (when the operator works outside a mission).
 
 **Scope:** plugin project only — `silent-stone-obsidian (plugin)` / project id `90f7de75-e92b-4287-84f0-0d5b703d9730` / team `LOCAL-DAILY` / key `LOC`.
 
-This command writes to git AND Linear. It is user-invoked only.
+This command writes to git AND opens a GitHub PR. **It never writes to Linear.** The ADR-004 Linear↔GitHub integration (Approach B) owns leaf-ticket state: branch detected → `In Progress`, PR merged → `Done`. Racing the integration with manual `save_issue` calls is the documented failure mode this rewrite eliminates.
 
-## Order of operations matters
+## Order of operations
 
-**Commit first, then flip Linear to Done.** A failed `git commit` must not leave a Linear ticket falsely closed. Never reverse this order. If the commit fails, stop — do not touch Linear.
+**Commit → push → PR.** Any failure in the chain stops without touching Linear. The integration's branch/PR webhooks handle every leaf-ticket state flip.
+
+If you're shipping the LAST sub-issue of a mission, you'll see a HINT to run `/ss-mission-status` afterward — that's where parent rollup happens lazily, against real merged-PR data. **Do not** flip the mission parent to Done from inside `/ss-ship`.
 
 ## Steps
 
@@ -26,7 +28,7 @@ git rev-parse --abbrev-ref HEAD
 Expected format: `josemoreno801/loc-NN-<slug>` (per the existing branch convention). Parse the `loc-NN` segment → `LOC-NN` (uppercase).
 
 **If the branch doesn't match the convention** (e.g. `main`, `chore/something`):
-- Print: `Branch <name> doesn't match the LOC-NN convention. Are you on the right branch? /ss-ship needs a ticketed branch to know what to close.`
+- Print: `Branch <name> doesn't match the LOC-NN convention. Are you on the right branch? /ss-ship needs a ticketed branch to know what to ship.`
 - Stop. The operator may have forgotten to `git checkout -b`.
 
 ### 2. Confirm the ticket exists and isn't already Done
@@ -36,13 +38,15 @@ get_issue("LOC-NN", includeRelations: true)
 ```
 
 - If 404 / not found: stop. Tell the operator the ID parsed from the branch doesn't exist in Linear.
-- If `state.type === "completed"`: stop. Tell the operator the ticket is already Done — they probably ran `/ss-ship` twice. Don't double-close.
+- If `state.type === "completed"`: stop. Ticket already Done means the integration already saw a merge for this branch. Re-shipping makes no sense — the operator is on a stale branch.
+
+(Backlog and In Progress are both acceptable here. The integration may have already flipped Backlog → In Progress when the branch was pushed; either state is fine to ship from.)
 
 ### 3. Determine mission context
 
 Check the returned ticket's `parent` field.
 
-- **Mission sub-issue**: `parent` is set. Confirm the parent's title starts with `Mission:` AND `parent.state.type !== "completed"` (the mission is still in flight). If both true, this `/ss-ship` is a mission step.
+- **Mission sub-issue**: `parent` is set. Confirm the parent's title starts with `Mission:` AND `parent.state.type !== "completed"`. If both true, this `/ss-ship` is a mission step.
 - **One-off ticket**: `parent` is null, OR `parent.title` doesn't start with `Mission:`, OR the mission parent is already Done. Treat as a standalone ship.
 
 ### 4. Propose the commit message
@@ -55,7 +59,7 @@ Soldier-mode voice. Two lines:
 <one-sentence why — what this changes for the user, not the code>
 ```
 
-`<type>` from the ticket's nature: `feat` (new behavior), `fix` (bug), `refactor` (no behavior change), `docs`, `chore`, `test`. Pick the closest fit; don't invent. `<scope>` is the code area touched (e.g. `plugin`, `crypto`, `ui`, `settings`, `sync`).
+`<type>` from the ticket's nature: `feat`, `fix`, `refactor`, `docs`, `chore`, `test`. Pick the closest fit; don't invent. `<scope>` is the code area touched (e.g. `plugin`, `crypto`, `ui`, `settings`, `sync`).
 
 Print the proposed message and ask: `Commit with this message? [y/N]`
 
@@ -73,78 +77,101 @@ git commit -m "<the proposed message>"
 Use a heredoc-style commit (see the workspace `CLAUDE.md` rules) and add the `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` line.
 
 **If `git commit` fails** (pre-commit hook, nothing to commit, signing failure):
-- Print the error. **Stop. Do not touch Linear.**
+- Print the error. **Stop. Do not push. Do not touch Linear.**
 - Investigate. Don't bypass hooks with `--no-verify` unless the operator explicitly asks.
 - Don't `--amend` to recover from a failed hook — create a new commit.
 
-**If commit succeeds:** print the new commit SHA + subject line. Then proceed.
+**If commit succeeds:** print the new commit SHA + subject line. Then proceed to push.
 
-### 6. Flip Linear to Done
+### 6. Push + open PR
 
-```
-save_issue(id: "LOC-NN", state: "Done")
-```
+Push the branch with upstream tracking:
 
-Immediately verify:
-
-```
-get_issue("LOC-NN")
+```bash
+git push -u origin <current-branch>
 ```
 
-Confirm `state.type === "completed"`. If verify fails, **say so loudly** — the operator needs to know Linear didn't actually update so they can fix it by hand. The commit already happened; the ticket just didn't close.
+If push fails (auth error, network, non-fast-forward) → print the error and stop. Do not force-push to recover. Do not touch Linear. The integration only flips state on a successful branch event from GitHub, so a failed push leaves Linear correctly unchanged.
 
-### 7. Mission rollup (if mission sub-issue)
+If push succeeds, open the PR:
+
+```bash
+gh pr create --fill --base main --repo josemoreno801-netizen/silent-stone-obsidian
+```
+
+`--fill` populates title and body from the commit message(s) on the branch. Capture the PR URL from gh's output.
+
+The integration will flip `LOC-NN` Backlog → In Progress within ~3s of branch push if it hadn't already. Don't poll for this — it's eventual-consistency by design.
+
+### 7. Mission-rollup hint (lazy, read-only)
 
 If step 3 determined this is a mission sub-issue:
 
-- `list_issues(parentId: "<parent.id>")` → all sub-issues with current states.
-- Count `Done` vs total.
-
-**Case A — mission still in flight** (some sub-issues are not Done):
 ```
-LOC-NN shipped. <X> of <N> done. /ss-pull for next.
+list_issues(parentId: "<parent.id>")
 ```
 
-**Case B — mission complete** (just-shipped sub-issue was the last Backlog/InProgress one):
-1. Compose a one-paragraph wrap-up comment (soldier-mode, no bullets, ~2–4 sentences). Mention each shipped LOC-NN inline. Note what's now usable.
-2. `save_comment(issueId: "<parent.id>", body: "<wrap text>")`
-3. `save_issue(id: "<parent.id>", state: "Done")`
-4. `get_issue("<parent.id>")` to verify — confirm `state.type === "completed"`.
-5. Print:
-   ```
-   Mission complete — <parent.title>
-   Wrap comment posted: <comment.url or parent.url>
-   Return to HQ.
-   ```
+Count Done vs total **without writing to Linear**. This is purely for the operator's awareness.
+
+**Case A — mission still has open sub-issues**:
+
+```
+LOC-NN shipped → PR opened. <X> of <N> sub-issues complete in <parent.title>. /ss-pull for next.
+```
+
+**Case B — every other sub-issue is already Done**:
+
+```
+LOC-NN shipped → PR opened. Looks like the last sub-issue of <parent.title>.
+Wait for the PR to merge (integration will flip LOC-NN to Done automatically).
+Then run /ss-mission-status to lazily roll up the parent.
+```
+
+The "looks like" hedge is intentional. At this point the just-shipped PR is OPEN, not merged — the integration hasn't flipped LOC-NN to Done yet. Parent rollup MUST wait for real merge confirmation. That happens in `/ss-mission-status`.
 
 ### 8. Non-mission shipping (one-off ticket)
 
 If step 3 determined this is a one-off:
 
 ```
-LOC-NN shipped. (one-off — not part of a mission)
+LOC-NN shipped → PR opened. (one-off — not part of a mission)
 ```
 
-End. No mission rollup, no parent comment. Don't refuse to ship — the operator can absolutely close a standalone ticket via `/ss-ship`.
+End. No mission rollup, no parent comment. Don't refuse to ship — the operator can absolutely PR a standalone ticket via `/ss-ship`.
+
+### 9. Final output (every path)
+
+After the path-specific message above, always print:
+
+```
+PR:     <gh pr url>
+Linear: <linear ticket url>
+Status: awaiting merge — integration flips LOC-NN to Done on merge.
+```
 
 ## Output discipline
 
 - Always show the proposed commit message **before** committing. Never auto-commit without explicit `y`.
-- Always print the resulting commit SHA after a successful commit so the operator can `git log` / push / verify.
+- Always print the resulting commit SHA after a successful commit.
+- Always print the PR URL + Linear URL + "awaiting merge" line at the end of a successful run.
 - Use the actual current date in any messaging, never placeholder dates.
 - Never echo or include any API keys, tokens, or secrets in commit messages or output.
 
 ## Anti-patterns (never do)
 
-- **Flipping Linear to Done before the commit succeeds.** Order is non-negotiable.
-- **Bypassing pre-commit hooks** with `--no-verify` unless the operator asks for it. Hook failures mean something is wrong; investigate.
+- **Flipping the leaf ticket to Done from this command.** The ADR-004 integration owns leaf state. Any `save_issue(state:"Done")` here is the racing pattern this rewrite eliminates. If you find one in the file, delete it.
+- **Flipping the mission parent to Done from this command.** Parent rollup is lazy — `/ss-mission-status`, `/ss-pull`, `/ss-status` handle it after the last sub-issue's PR actually merges, not before.
+- **Pushing before commit succeeds.** Order is `commit` → verify success → `push`. Any failure stops the chain.
+- **Bypassing pre-commit hooks** with `--no-verify` unless the operator asks.
 - **Amending the previous commit** to recover from a failed pre-commit hook. The failed commit didn't land — amending would modify the wrong commit. Create a new commit.
-- **Refusing to ship one-off tickets.** The plan explicitly requires `/ss-ship` to handle non-mission shipping. Don't gate-keep.
-- **Posting a wrap comment on a half-finished mission.** Wrap only fires when the LAST sub-issue ships. Re-count after the state transition.
-- **Skipping the `get_issue` verify** after any Linear write. Silent-failure landmine.
+- **Force-pushing** to recover from a non-fast-forward push. Investigate — the branch is likely out of sync with origin; force-push masks the real problem.
+- **Refusing to ship one-off tickets.** This command handles both mission and standalone work.
+- **Skipping `--repo` on `gh pr create`.** Cross-repo confusion is a real failure mode in multi-repo workflows.
 
 ## Landmines
 
-1. Branch parsing assumes `loc-NN` lowercase in the branch. If the operator named it `LOC-NN` (uppercase mid-branch), be tolerant — match case-insensitively, normalize to `LOC-NN` for Linear.
-2. `save_comment` and `save_issue` are separate MCP calls. The mission-complete path runs both — verify each independently.
-3. Linear's `query: "Mission:"` is a broad search. Step 3 already has the parent in hand from `get_issue includeRelations:true`, so this command never needs to search by title. Don't fall back to title search.
+1. Branch parsing assumes `loc-NN` lowercase. Be tolerant — match case-insensitively, normalize to `LOC-NN` for Linear.
+2. `gh pr create --fill` uses the last commit's message as the PR title and body. Multi-commit branches will have a sparse body — that's fine for now; the operator can edit on GitHub.
+3. The integration's branch → In Progress flip can take ~3s after `git push`. Don't poll Linear immediately after push expecting an updated state.
+4. `--base main` is hardcoded. If the operator needs to PR against a feature branch, they should use raw `gh pr create` and skip this command.
+5. If the PR ends up open but the operator decides not to land it, **don't** flip Linear back to Backlog manually — close the PR on GitHub and the integration will reflect it. Manual writes are still the failure mode.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,3 +139,13 @@ This repo (`silent-stone-obsidian`) is the **public, open-source** Obsidian plug
 - **Why it's public**: Silent Stone promises end-to-end encryption — "your server never sees plaintext." This repo is the proof. Customers, security researchers, and skeptics can audit `src/crypto/` to verify encryption happens client-side.
 - **Related private repo**: The server that serves `/api/vault/*` endpoints is proprietary (handles billing, admin dashboard, infrastructure). Its privacy does not weaken the encryption claim — the plugin's crypto is what matters, and it's fully visible here.
 - **Issues and roadmap**: Open a GitHub issue here for any plugin-specific bug, feature, or crypto concern. Server-coupled work is tracked in the private repo.
+
+## Auto-load on session start
+
+When a Claude Code session boots in this project (the repo root OR any worktree under `.claude/worktrees/`), check the current working directory for `WORKTREE_PROMPT.md` or `MISSION_PROMPT.md`. If either file exists:
+
+1. Read its contents.
+2. Treat the contents as the operator's initial prompt and execute on it as if they had typed it.
+3. Delete the file (`rm WORKTREE_PROMPT.md` or `rm MISSION_PROMPT.md`) after reading — these are transient handshake files, not persistent docs.
+
+`/ss-pull` writes `WORKTREE_PROMPT.md` when it spawns a worktree session. `/ss-mission` (at HQ) writes `MISSION_PROMPT.md` when it spawns a field session. Both are part of the tmux-window spawn flow: HQ → field, field → worktree, prompt delivered via file because `claude --tmux <prompt>` doesn't honor positional prompt args.


### PR DESCRIPTION
## Summary

Wires the plugin field commands (`/ss-ship`, `/ss-pull`, `/ss-mission-status`) and project `CLAUDE.md` to ADR-004 Approach B (Linear↔GitHub integration). The integration owns leaf-ticket state transitions (Backlog → In Progress on PR open, → Done on PR merge); field commands stop racing it.

Closes [LOC-50](https://linear.app/local-daily/issue/LOC-50/wire-adr-004-integration-into-plugin-field-commands-ss-ship-ss-pull-ss).

## Changes

Three commits, each focused on one command:

### 1. `feat(plugin): /ss-ship stops at PR; integration owns Linear Done` (f8dcab2)

- Removes `save_issue(state:"Done")` on the leaf ticket.
- Replaces with `git push -u origin <branch>` then `gh pr create --fill`.
- Mission-parent rollup becomes a **read-only hint** — no parent flips from this command.
- Final output: PR URL + Linear URL + "awaiting merge".

### 2. `feat(plugin): /ss-pull spawns worktree in tmux window + lazy parent rollup` (a9f9f87)

- Full rewrite of the post-claim flow:
  1. Stale-worktree sweep (`git worktree list` filtered to `.claude/worktrees/loc-*`).
  2. **Lazy mission-parent rollup pass** — closes parents whose children are all Done.
  3. WIP-1 enforcement via active worktrees (not Linear state).
  4. Find active mission → pick next Backlog sub-issue → echo briefing.
  5. **Spawn**: `git worktree add` + write `WORKTREE_PROMPT.md` + `tmux new-window -c <abs-path> "claude --debug"`.
- `$TMUX` guard hard-fails (Option A safety, no fallback).
- Drops the leaf `save_issue(state:"In Progress")` — integration handles that on PR open.
- **CLAUDE.md amendment** at repo root: spawned sessions read `WORKTREE_PROMPT.md` / `MISSION_PROMPT.md` on startup, execute as initial prompt, then delete the file.

### 3. `feat(plugin): /ss-mission-status: lazy parent rollup pass` (fd8740a)

- Adds the same lazy rollup as step 2 above, before rendering the checklist.
- Revises the contract: was "Read-only. No writes." → now "One bounded write only: the rollup."
- Step 3's "All sub-issues Done" verdict becomes defensive-only (normally unreachable after step 0 fires).

## Architectural rationale

The original `/ss-ship` raced the integration: command flipped Linear Done, integration also flipped Linear Done (slightly later, via PR-merge webhook). Two writers → either could lose, depending on order. ADR-004 Approach B (no code access — pure GitHub-integration plumbing) consolidates leaf state under the integration, leaving field commands write-free for leaves.

Mission-parent rollup is the one exception. The integration doesn't auto-close parents; without lazy rollup somewhere, parents stay In Progress forever after their children finish. Embedding the rollup in `/ss-pull` + `/ss-mission-status` (and HQ's `/ss-status`, separate PR) means parents close on next operator interaction.

Spawn architecture (`/ss-pull` step 8–10) pivoted from the originally-planned native `claude --worktree --tmux <prompt>` after Phase 0 smoke test showed:
- `--tmux` spawns a separate tmux session, not a window in the current session.
- Positional prompt arg is silently ignored.

Replacement: manual `git worktree add` + file-based prompt delivery (`WORKTREE_PROMPT.md`) + `tmux new-window` for current-session windowing. Documented divergence from `superpowers:using-git-worktrees`; justified by Phase 0 evidence.

## What this PR doesn't touch

- LOC-47 branch (`josemoreno801/loc-47-add-divergence-based-conflict-detection-to-sync-engine`) — left alone per operator.
- `.claude/settings.local.json` is gitignored (line 14) — permissions stay per-user.
- `.gitignore` already covers `.claude/worktrees/` (line 18) — no changes needed.

## Test plan

- [ ] After merge: integration flips LOC-50 Backlog → Done within ~3s.
- [ ] E2E test deferred to post-PR-3 verification (see `/Users/danielremigiorivera/.claude/plans/now-lets-finish-where-misty-hartmanis.md` § Verification).
- [ ] Specifically: `/ss-ship` on a fresh sub-issue must leave the ticket In Progress (NOT Done) — proves the race is gone.
- [ ] `/ss-pull` spawns a tmux window with `claude --debug` and `WORKTREE_PROMPT.md` is auto-loaded then deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)