### PR TITLE
feat(sync): divergence-based conflict detection (LOC-47)

### DIFF
--- a/src/__tests__/known-synced-migration.test.ts
+++ b/src/__tests__/known-synced-migration.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { hydrateKnownSynced } from '../sync/known-synced';
+
+// hydrateKnownSynced is the boundary between persisted state and the engine.
+// It must accept three shapes — legacy paths-only array, post-LOC-47 record,
+// and absent / garbage — and never throw, so an upgrade across plugin versions
+// degrades gracefully instead of locking the user out of sync.
+
+describe('hydrateKnownSynced — legacy paths-only array', () => {
+  it('maps every path to the empty-string sentinel ("preserve local, record real hash next round")', () => {
+    const result = hydrateKnownSynced(['a.md', 'subfolder/b.md']);
+    expect(result.size).toBe(2);
+    expect(result.get('a.md')).toBe('');
+    expect(result.get('subfolder/b.md')).toBe('');
+  });
+
+  it('drops non-string entries defensively', () => {
+    const result = hydrateKnownSynced(['ok.md', 42, null, undefined, { broken: true }]);
+    expect([...result.keys()]).toEqual(['ok.md']);
+  });
+
+  it('returns an empty Map for an empty array', () => {
+    const result = hydrateKnownSynced([]);
+    expect(result.size).toBe(0);
+  });
+});
+
+describe('hydrateKnownSynced — current Record<path, hash> shape', () => {
+  it('round-trips a JSON-serialized Map back into a Map', () => {
+    const original = new Map<string, string>([
+      ['a.md', 'abc123'],
+      ['nested/b.md', 'def456'],
+    ]);
+    const serialized = Object.fromEntries(original);
+    const result = hydrateKnownSynced(serialized);
+    expect(result).toEqual(original);
+  });
+
+  it('drops entries whose value is not a string', () => {
+    const result = hydrateKnownSynced({
+      'good.md': 'hash',
+      'broken.md': 42,
+      'alsoBroken.md': null,
+      'object.md': { nested: true },
+    });
+    expect([...result.keys()]).toEqual(['good.md']);
+    expect(result.get('good.md')).toBe('hash');
+  });
+});
+
+describe('hydrateKnownSynced — absent or unknown shapes', () => {
+  it('returns empty Map for null', () => {
+    expect(hydrateKnownSynced(null).size).toBe(0);
+  });
+  it('returns empty Map for undefined', () => {
+    expect(hydrateKnownSynced(undefined).size).toBe(0);
+  });
+  it('returns empty Map for a string', () => {
+    expect(hydrateKnownSynced('garbage').size).toBe(0);
+  });
+  it('returns empty Map for a number', () => {
+    expect(hydrateKnownSynced(42).size).toBe(0);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,8 @@ import {
 import type { WrappedKey } from './crypto/types';
 import { ManifestManager } from './sync/manifest';
 import { FileWatcher } from './sync/watcher';
-import { SyncEngine } from './sync/engine';
+import { SyncEngine, type ConflictHandler, type ConflictResolution } from './sync/engine';
+import { hydrateKnownSynced } from './sync/known-synced';
 import { compileIgnorePrefixes, isIgnored } from './sync/ignore';
 import { LoginModal } from './ui/login-modal';
 import { LogoutModal } from './ui/logout-modal';
@@ -394,7 +395,7 @@ export default class SilentStoneSyncPlugin extends Plugin {
     const ignorePrefixes = compileIgnorePrefixes(this.settings.ignorePaths);
 
     const persisted = (await this.loadData()) ?? {};
-    const knownSynced = new Set<string>(persisted[KNOWN_SYNCED_KEY] ?? []);
+    const knownSynced = hydrateKnownSynced(persisted[KNOWN_SYNCED_KEY]);
 
     const engine = new SyncEngine({
       client: vaultClient,
@@ -420,6 +421,7 @@ export default class SilentStoneSyncPlugin extends Plugin {
       },
       masterKey,
       knownSynced,
+      onConflict: this.makeConflictHandler(),
       onStatusChange: (event) => {
         this.status =
           event.state === 'idle' ? 'idle' : event.state === 'syncing' ? 'syncing' : 'error';
@@ -443,7 +445,7 @@ export default class SilentStoneSyncPlugin extends Plugin {
       },
       onStateUpdate: async (ks) => {
         const data = (await this.loadData()) ?? {};
-        data[KNOWN_SYNCED_KEY] = [...ks];
+        data[KNOWN_SYNCED_KEY] = Object.fromEntries(ks);
         await this.saveData(data);
       },
     });
@@ -453,6 +455,28 @@ export default class SilentStoneSyncPlugin extends Plugin {
     this.vaultKey = masterKey;
     this.status = 'idle';
     this.updateStatusBar();
+  }
+
+  /**
+   * Build the conflict handler the engine consults when a real divergence is detected.
+   * Honors `settings.conflictStrategy`:
+   *   - `keep-local` / `keep-server` / `keep-both` → return directly.
+   *   - `ask` → fall back to `keep-server` until LOC-12 lands the modal. A Notice
+   *     surfaces the fallback so the user is aware their `'ask'` preference is being
+   *     deferred (rather than silently picking server).
+   */
+  private makeConflictHandler(): ConflictHandler {
+    return (info): ConflictResolution => {
+      const strategy = this.settings.conflictStrategy;
+      if (strategy === 'keep-local' || strategy === 'keep-server' || strategy === 'keep-both') {
+        return strategy;
+      }
+      new Notice(
+        `Conflict on ${info.path}: keeping server copy (interactive prompt coming in a future update).`,
+        6000,
+      );
+      return 'keep-server';
+    };
   }
 
   lockVault(): void {

--- a/src/sync/__tests__/engine.test.ts
+++ b/src/sync/__tests__/engine.test.ts
@@ -11,7 +11,12 @@ vi.mock('obsidian', () => ({
 import { VaultClient } from '../../api/vault-client';
 import { encryptBlob } from '../../crypto/cipher';
 import { ManifestManager } from '../manifest';
-import { SyncEngine, type SyncVault } from '../engine';
+import {
+  SyncEngine,
+  type ConflictInfo,
+  type ConflictResolution,
+  type SyncVault,
+} from '../engine';
 import type { ChangeEvent } from '../watcher';
 import type { ManifestEntry } from '../manifest';
 import type { SyncStatusEvent } from '../../types';
@@ -96,11 +101,13 @@ interface Harness {
   vault: FakeVault;
   client: VaultClient;
   statuses: string[];
-  savedKnownSynced: Set<string>[];
+  savedKnownSynced: Map<string, string>[];
+  conflictCalls: ConflictInfo[];
 }
 
 interface HarnessOpts {
-  knownSynced?: Set<string>;
+  knownSynced?: Map<string, string>;
+  onConflict?: (info: ConflictInfo) => ConflictResolution | Promise<ConflictResolution>;
 }
 
 /** Assemble a fresh engine with empty manifest (404 on first getManifest). */
@@ -115,7 +122,8 @@ async function makeHarness(opts: HarnessOpts = {}): Promise<Harness> {
   const queue = new FakeQueue();
   const vault = new FakeVault();
   const statuses: string[] = [];
-  const savedKnownSynced: Set<string>[] = [];
+  const savedKnownSynced: Map<string, string>[] = [];
+  const conflictCalls: ConflictInfo[] = [];
   const engine = new SyncEngine({
     client,
     manifest,
@@ -125,10 +133,16 @@ async function makeHarness(opts: HarnessOpts = {}): Promise<Harness> {
     onStatusChange: (e) => statuses.push(e.state),
     knownSynced: opts.knownSynced,
     onStateUpdate: async (ks) => {
-      savedKnownSynced.push(new Set(ks));
+      savedKnownSynced.push(new Map(ks));
     },
+    onConflict: opts.onConflict
+      ? (info) => {
+          conflictCalls.push(info);
+          return opts.onConflict!(info);
+        }
+      : undefined,
   });
-  return { engine, manifest, queue, vault, client, statuses, savedKnownSynced };
+  return { engine, manifest, queue, vault, client, statuses, savedKnownSynced, conflictCalls };
 }
 
 beforeEach(() => {
@@ -391,11 +405,15 @@ describe('SyncEngine.pullChanges — new files from server', () => {
     expect(new TextDecoder().decode(local)).toBe('server file');
   });
 
-  it('uses vault.modify when the local file already exists and hash differs', async () => {
-    const h = await makeHarness();
-    const blobId = '66666666-6666-4666-8666-666666666666';
+  it('uses vault.modify when the local file already exists and hash differs (one-sided server change)', async () => {
+    // Setup: local hash === lastKnown === oldPlaintext hash. Server moved to newPlaintext.
+    // This is case 4 in the divergence matrix — server moved, local didn't → download.
     const newPlaintext = new TextEncoder().encode('new version').buffer as ArrayBuffer;
     const oldPlaintext = new TextEncoder().encode('old version').buffer as ArrayBuffer;
+    const oldHash = await sha256Hex(oldPlaintext);
+
+    const h = await makeHarness({ knownSynced: new Map([['doc.md', oldHash]]) });
+    const blobId = '66666666-6666-4666-8666-666666666666';
     h.vault.files.set('doc.md', oldPlaintext);
 
     const encryptedBlob = await encryptBlob(new Uint8Array(newPlaintext), MASTER_KEY);
@@ -453,9 +471,11 @@ describe('SyncEngine.pullChanges — new files from server', () => {
 
 describe('SyncEngine.pullChanges — deletions with known-synced guard', () => {
   it('deletes local file that was previously synced but no longer in manifest', async () => {
-    const h = await makeHarness({ knownSynced: new Set(['old.md']) });
-    const plaintext = new TextEncoder().encode('to delete').buffer as ArrayBuffer;
-    h.vault.files.set('old.md', plaintext);
+    const oldPlaintext = new TextEncoder().encode('to delete').buffer as ArrayBuffer;
+    const h = await makeHarness({
+      knownSynced: new Map([['old.md', await sha256Hex(oldPlaintext)]]),
+    });
+    h.vault.files.set('old.md', oldPlaintext);
 
     const encManifest = await encryptManifest(
       { version: 1, entries: {} },
@@ -516,7 +536,10 @@ describe('SyncEngine.pullChanges — deletions with known-synced guard', () => {
 
     expect(h.savedKnownSynced.length).toBeGreaterThan(0);
     const latest = h.savedKnownSynced[h.savedKnownSynced.length - 1];
-    expect([...latest].sort()).toEqual(['a.md', 'b.md']);
+    expect([...latest.keys()].sort()).toEqual(['a.md', 'b.md']);
+    // And the values are the file's plaintext hash, not just paths.
+    expect(latest.get('a.md')).toBe(await sha256Hex(plaintext));
+    expect(latest.get('b.md')).toBe(await sha256Hex(plaintext));
   });
 });
 
@@ -734,12 +757,19 @@ describe('SyncEngine.pushChanges — pre-existing vault files (no watcher events
 
 describe('SyncEngine.pushChanges — deletion via diff with knownSynced guard', () => {
   it('deletes blobs for files in manifest + knownSynced that are missing locally, with no watcher event', async () => {
-    const h = await makeHarness({ knownSynced: new Set(['a.md', 'b.md']) });
-
     const a = new TextEncoder().encode('alpha').buffer as ArrayBuffer;
+    const aHash = await sha256Hex(a);
+    // knownSynced maps each previously-synced path to its last-known plaintext hash.
+    // For b.md we don't have the bytes anymore — use the same placeholder hash that the
+    // manifest entry below uses, so it's consistent with the per-path-hash contract.
+    const h = await makeHarness({
+      knownSynced: new Map([
+        ['a.md', aHash],
+        ['b.md', 'beta-hash'],
+      ]),
+    });
     h.vault.files.set('a.md', a);
 
-    const aHash = await sha256Hex(a);
     h.manifest.setEntry('a.md', {
       blobId: '11111111-1111-4111-8111-111111111111',
       size: a.byteLength,
@@ -789,5 +819,313 @@ describe('SyncEngine.pushChanges — orphan guard', () => {
     expect(h.manifest.getEntry('orphan.md')).toBeDefined();
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
+  });
+});
+
+// ── pullChanges — divergence-based conflict detection (LOC-47) ────
+// Three reference points decide which case fires:
+//   localHash  — sha256 of the file on disk right now
+//   serverHash — manifestEntry.hash (server side after decryption)
+//   lastKnown  — knownSynced.get(path) — what was on disk last successful sync
+//
+// Conflict (case 5) iff localHash !== serverHash AND lastKnown !== localHash AND
+// lastKnown !== serverHash. Anything else is a one-sided change or "in sync."
+describe('SyncEngine.pullChanges — divergence-based conflict detection', () => {
+  /** Build an encrypted blob + manifest containing `path → entry`. */
+  async function buildServerState(
+    path: string,
+    plaintext: ArrayBuffer,
+    blobId: string,
+  ): Promise<{ entry: ManifestEntry; blobBuf: ArrayBuffer; encManifest: ArrayBuffer }> {
+    const encryptedBlob = await encryptBlob(new Uint8Array(plaintext), MASTER_KEY);
+    const blobBuf = new ArrayBuffer(encryptedBlob.byteLength);
+    new Uint8Array(blobBuf).set(encryptedBlob);
+    const entry: ManifestEntry = {
+      blobId,
+      size: plaintext.byteLength,
+      hash: await sha256Hex(plaintext),
+      modifiedAt: 99,
+    };
+    const encManifest = await encryptManifest(
+      { version: 1, entries: { [path]: entry } },
+      MASTER_KEY,
+    );
+    return { entry, blobBuf, encManifest };
+  }
+
+  it('case 3 — one-sided local change: lastKnown matches server, local moved → preserves local, no download', async () => {
+    const serverPlaintext = new TextEncoder().encode('shared').buffer as ArrayBuffer;
+    const localPlaintext = new TextEncoder().encode('local edits').buffer as ArrayBuffer;
+    const serverHash = await sha256Hex(serverPlaintext);
+    const localHash = await sha256Hex(localPlaintext);
+
+    // lastKnown === serverHash → user edited locally since last sync. Server unchanged.
+    const h = await makeHarness({ knownSynced: new Map([['notes.md', serverHash]]) });
+    h.vault.files.set('notes.md', localPlaintext);
+
+    const { encManifest } = await buildServerState(
+      'notes.md',
+      serverPlaintext,
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    );
+    mockRequestUrl.mockResolvedValueOnce(
+      okBinary(encManifest, { 'x-sequence-number': '1' }),
+    );
+
+    await h.engine.pullChanges();
+
+    // Local untouched — bytes still match local edit.
+    const stillLocal = await h.vault.readBinary('notes.md');
+    expect(new TextDecoder().decode(stillLocal)).toBe('local edits');
+    // Only the manifest GET — no blob download.
+    expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+    // No conflict handler call.
+    expect(h.conflictCalls).toHaveLength(0);
+    // Persisted knownSynced now reflects the actual local hash.
+    const latest = h.savedKnownSynced.at(-1)!;
+    expect(latest.get('notes.md')).toBe(localHash);
+  });
+
+  it('case 4 — one-sided server change: lastKnown matches local, server moved → downloads', async () => {
+    const oldPlaintext = new TextEncoder().encode('original').buffer as ArrayBuffer;
+    const newServerPlaintext = new TextEncoder().encode('server-updated').buffer as ArrayBuffer;
+    const oldHash = await sha256Hex(oldPlaintext);
+
+    // lastKnown === localHash (oldHash) → local unchanged. Server moved to new content.
+    const h = await makeHarness({ knownSynced: new Map([['notes.md', oldHash]]) });
+    h.vault.files.set('notes.md', oldPlaintext);
+
+    const { blobBuf, encManifest } = await buildServerState(
+      'notes.md',
+      newServerPlaintext,
+      'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+    );
+    mockRequestUrl.mockResolvedValueOnce(
+      okBinary(encManifest, { 'x-sequence-number': '2' }),
+    );
+    mockRequestUrl.mockResolvedValueOnce(okBinary(blobBuf));
+
+    await h.engine.pullChanges();
+
+    const after = await h.vault.readBinary('notes.md');
+    expect(new TextDecoder().decode(after)).toBe('server-updated');
+    expect(h.conflictCalls).toHaveLength(0);
+  });
+
+  it('case 5 — both sides changed: conflict handler fires with all three hashes', async () => {
+    const baselinePlaintext = new TextEncoder().encode('baseline v1').buffer as ArrayBuffer;
+    const localPlaintext = new TextEncoder().encode('local changes').buffer as ArrayBuffer;
+    const serverPlaintext = new TextEncoder().encode('server changes').buffer as ArrayBuffer;
+    const baselineHash = await sha256Hex(baselinePlaintext);
+    const localHash = await sha256Hex(localPlaintext);
+    const serverHash = await sha256Hex(serverPlaintext);
+
+    const onConflict = vi.fn<(info: ConflictInfo) => ConflictResolution>(() => 'keep-local');
+    const h = await makeHarness({
+      knownSynced: new Map([['notes.md', baselineHash]]),
+      onConflict,
+    });
+    h.vault.files.set('notes.md', localPlaintext);
+
+    const { blobBuf, encManifest } = await buildServerState(
+      'notes.md',
+      serverPlaintext,
+      'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+    );
+    mockRequestUrl.mockResolvedValueOnce(
+      okBinary(encManifest, { 'x-sequence-number': '3' }),
+    );
+    mockRequestUrl.mockResolvedValueOnce(okBinary(blobBuf));
+
+    await h.engine.pullChanges();
+
+    expect(onConflict).toHaveBeenCalledOnce();
+    const info = h.conflictCalls[0];
+    expect(info.path).toBe('notes.md');
+    expect(info.localHash).toBe(localHash);
+    expect(info.serverHash).toBe(serverHash);
+    expect(info.lastKnownHash).toBe(baselineHash);
+    // localContent and serverContent should round-trip the plaintexts.
+    expect(new TextDecoder().decode(info.localContent)).toBe('local changes');
+    expect(new TextDecoder().decode(info.serverContent)).toBe('server changes');
+  });
+
+  it('case 5 resolution: keep-local → preserves local bytes, knownSynced tracks localHash', async () => {
+    const baseline = new TextEncoder().encode('baseline').buffer as ArrayBuffer;
+    const local = new TextEncoder().encode('local').buffer as ArrayBuffer;
+    const server = new TextEncoder().encode('server').buffer as ArrayBuffer;
+    const localHash = await sha256Hex(local);
+
+    const h = await makeHarness({
+      knownSynced: new Map([['n.md', await sha256Hex(baseline)]]),
+      onConflict: () => 'keep-local',
+    });
+    h.vault.files.set('n.md', local);
+
+    const { blobBuf, encManifest } = await buildServerState(
+      'n.md',
+      server,
+      'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+    );
+    mockRequestUrl.mockResolvedValueOnce(
+      okBinary(encManifest, { 'x-sequence-number': '4' }),
+    );
+    mockRequestUrl.mockResolvedValueOnce(okBinary(blobBuf));
+
+    await h.engine.pullChanges();
+
+    expect(new TextDecoder().decode(await h.vault.readBinary('n.md'))).toBe('local');
+    expect(h.savedKnownSynced.at(-1)!.get('n.md')).toBe(localHash);
+  });
+
+  it('case 5 resolution: keep-server → vault.modify with server bytes, knownSynced tracks serverHash', async () => {
+    const baseline = new TextEncoder().encode('baseline').buffer as ArrayBuffer;
+    const local = new TextEncoder().encode('local').buffer as ArrayBuffer;
+    const server = new TextEncoder().encode('server').buffer as ArrayBuffer;
+    const serverHash = await sha256Hex(server);
+
+    const h = await makeHarness({
+      knownSynced: new Map([['n.md', await sha256Hex(baseline)]]),
+      onConflict: () => 'keep-server',
+    });
+    h.vault.files.set('n.md', local);
+
+    const { blobBuf, encManifest } = await buildServerState(
+      'n.md',
+      server,
+      'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+    );
+    mockRequestUrl.mockResolvedValueOnce(
+      okBinary(encManifest, { 'x-sequence-number': '5' }),
+    );
+    mockRequestUrl.mockResolvedValueOnce(okBinary(blobBuf));
+
+    await h.engine.pullChanges();
+
+    expect(new TextDecoder().decode(await h.vault.readBinary('n.md'))).toBe('server');
+    expect(h.savedKnownSynced.at(-1)!.get('n.md')).toBe(serverHash);
+  });
+
+  it('case 5 resolution: keep-both → server saved at suffixed path, local untouched', async () => {
+    const baseline = new TextEncoder().encode('baseline').buffer as ArrayBuffer;
+    const local = new TextEncoder().encode('local').buffer as ArrayBuffer;
+    const server = new TextEncoder().encode('server').buffer as ArrayBuffer;
+
+    const h = await makeHarness({
+      knownSynced: new Map([['n.md', await sha256Hex(baseline)]]),
+      onConflict: () => 'keep-both',
+    });
+    h.vault.files.set('n.md', local);
+
+    const { blobBuf, encManifest } = await buildServerState(
+      'n.md',
+      server,
+      'ffffffff-ffff-4fff-8fff-ffffffffffff',
+    );
+    mockRequestUrl.mockResolvedValueOnce(
+      okBinary(encManifest, { 'x-sequence-number': '6' }),
+    );
+    mockRequestUrl.mockResolvedValueOnce(okBinary(blobBuf));
+
+    await h.engine.pullChanges();
+
+    // Local untouched.
+    expect(new TextDecoder().decode(await h.vault.readBinary('n.md'))).toBe('local');
+    // Some other path was created that contains the server bytes and has the
+    // conflict-copy marker in its name.
+    const created = [...h.vault.files.keys()].filter((p) => p !== 'n.md');
+    expect(created.length).toBe(1);
+    expect(created[0]).toMatch(/conflict copy/);
+    expect(new TextDecoder().decode(await h.vault.readBinary(created[0]))).toBe('server');
+  });
+
+  it('migration sentinel (empty-string value) → preserves local, records actual local hash, no conflict prompt', async () => {
+    // Simulates the legacy persisted shape after main.ts hydrates it: every previously
+    // known path is in the map but the value is `''` (no real history). The first round
+    // after the upgrade must NOT false-positive into a conflict.
+    const localPlaintext = new TextEncoder().encode('local-only edits').buffer as ArrayBuffer;
+    const serverPlaintext = new TextEncoder().encode('different content').buffer as ArrayBuffer;
+    const localHash = await sha256Hex(localPlaintext);
+
+    const onConflict = vi.fn<(info: ConflictInfo) => ConflictResolution>(() => 'keep-server');
+    const h = await makeHarness({
+      knownSynced: new Map([['legacy.md', '']]), // migration sentinel
+      onConflict,
+    });
+    h.vault.files.set('legacy.md', localPlaintext);
+
+    const { encManifest } = await buildServerState(
+      'legacy.md',
+      serverPlaintext,
+      'aaaaaaaa-aaaa-4aaa-8aaa-bbbbbbbbbbbb',
+    );
+    mockRequestUrl.mockResolvedValueOnce(
+      okBinary(encManifest, { 'x-sequence-number': '7' }),
+    );
+
+    await h.engine.pullChanges();
+
+    // Local preserved despite differing from server (sentinel ≠ confirmed conflict).
+    expect(new TextDecoder().decode(await h.vault.readBinary('legacy.md'))).toBe(
+      'local-only edits',
+    );
+    expect(onConflict).not.toHaveBeenCalled();
+    // Hash now real — next round will have a proper anchor.
+    expect(h.savedKnownSynced.at(-1)!.get('legacy.md')).toBe(localHash);
+    // Only the manifest GET was made — no blob fetch.
+    expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it('no handler wired + real conflict → defaults to keep-server with a console.warn', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const baseline = new TextEncoder().encode('baseline').buffer as ArrayBuffer;
+    const local = new TextEncoder().encode('local').buffer as ArrayBuffer;
+    const server = new TextEncoder().encode('server').buffer as ArrayBuffer;
+
+    const h = await makeHarness({
+      knownSynced: new Map([['n.md', await sha256Hex(baseline)]]),
+      // onConflict deliberately omitted
+    });
+    h.vault.files.set('n.md', local);
+
+    const { blobBuf, encManifest } = await buildServerState(
+      'n.md',
+      server,
+      'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+    );
+    mockRequestUrl.mockResolvedValueOnce(
+      okBinary(encManifest, { 'x-sequence-number': '8' }),
+    );
+    mockRequestUrl.mockResolvedValueOnce(okBinary(blobBuf));
+
+    await h.engine.pullChanges();
+
+    expect(new TextDecoder().decode(await h.vault.readBinary('n.md'))).toBe('server');
+    expect(warnSpy).toHaveBeenCalled();
+    const warnArg = warnSpy.mock.calls[0]?.[0] as string;
+    expect(warnArg).toMatch(/conflict on n\.md/);
+    warnSpy.mockRestore();
+  });
+});
+
+// ── pushChanges — knownSynced records per-file hash (LOC-47) ────
+describe('SyncEngine.pushChanges — knownSynced carries per-file hash', () => {
+  it('after upload, persisted knownSynced maps each pushed path to its plaintext sha256', async () => {
+    const h = await makeHarness();
+    const plaintextA = new TextEncoder().encode('alpha').buffer as ArrayBuffer;
+    const plaintextB = new TextEncoder().encode('beta').buffer as ArrayBuffer;
+    h.vault.files.set('a.md', plaintextA);
+    h.vault.files.set('b.md', plaintextB);
+    h.queue.events = [{ kind: 'upsert', path: 'a.md' }];
+
+    mockRequestUrl.mockResolvedValueOnce(okJson({ ok: true, blobId: 'x', size: 5 }));
+    mockRequestUrl.mockResolvedValueOnce(okJson({ ok: true, blobId: 'x', size: 4 }));
+    mockRequestUrl.mockResolvedValueOnce(okJson({ ok: true, sequenceNumber: 1 }));
+
+    await h.engine.pushChanges();
+
+    const latest = h.savedKnownSynced.at(-1)!;
+    expect(latest.get('a.md')).toBe(await sha256Hex(plaintextA));
+    expect(latest.get('b.md')).toBe(await sha256Hex(plaintextB));
   });
 });

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -23,6 +23,22 @@ export interface QueueSource {
   clearQueue(): void;
 }
 
+export type ConflictResolution = 'keep-local' | 'keep-server' | 'keep-both';
+
+export interface ConflictInfo {
+  path: string;
+  localHash: string;
+  serverHash: string;
+  /** Hash on disk the last time this file was successfully synced. Empty string when migrating from the legacy paths-only persisted shape (no reliable history). */
+  lastKnownHash: string;
+  localContent: ArrayBuffer;
+  serverContent: ArrayBuffer;
+  /** Manifest entry's modifiedAt for the server side. */
+  serverModifiedAt: number;
+}
+
+export type ConflictHandler = (info: ConflictInfo) => Promise<ConflictResolution> | ConflictResolution;
+
 export interface SyncEngineOpts {
   client: VaultClient;
   manifest: ManifestManager;
@@ -30,10 +46,23 @@ export interface SyncEngineOpts {
   vault: SyncVault;
   masterKey: Uint8Array;
   onStatusChange?: (event: SyncStatusEvent) => void;
-  /** Paths known to have been synced on a previous successful sync. Guards against wiping unsynced local work. */
-  knownSynced?: Set<string>;
-  /** Called after every successful sync with the updated known-synced set so the caller can persist it. */
-  onStateUpdate?: (knownSynced: Set<string>) => Promise<void> | void;
+  /**
+   * Last-known plaintext hash per synced path. Lets the engine distinguish a real
+   * divergence (both sides changed since last sync) from a one-sided change.
+   * Empty-string values are migration sentinels (legacy state had paths only, no
+   * hashes); the engine treats them as "preserve local, record the actual hash
+   * next round" so an upgrade can't false-positive into a conflict storm.
+   */
+  knownSynced?: Map<string, string>;
+  /** Called after every successful sync with the updated known-synced map so the caller can persist it. */
+  onStateUpdate?: (knownSynced: Map<string, string>) => Promise<void> | void;
+  /**
+   * Called when a real divergence is detected (local and server both changed since
+   * last known sync). Resolution drives what the engine does with the file. If not
+   * provided, the engine defaults to 'keep-server' with a console warning — same
+   * effective behavior as pre-LOC-47 silent clobber but now flagged.
+   */
+  onConflict?: ConflictHandler;
 }
 
 async function sha256Hex(data: ArrayBuffer): Promise<string> {
@@ -50,6 +79,17 @@ function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   return buf;
 }
 
+/** Build the keep-both conflict-copy path: `notes/foo.md` → `notes/foo (conflict copy <iso-date>).md`. */
+function makeConflictCopyPath(path: string): string {
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const dot = path.lastIndexOf('.');
+  const slash = path.lastIndexOf('/');
+  if (dot > slash && dot > 0) {
+    return `${path.slice(0, dot)} (conflict copy ${stamp})${path.slice(dot)}`;
+  }
+  return `${path} (conflict copy ${stamp})`;
+}
+
 export class SyncEngine {
   private readonly client: VaultClient;
   private readonly manifest: ManifestManager;
@@ -57,8 +97,9 @@ export class SyncEngine {
   private readonly vault: SyncVault;
   private readonly masterKey: Uint8Array;
   private readonly onStatusChange?: (event: SyncStatusEvent) => void;
-  private readonly onStateUpdate?: (knownSynced: Set<string>) => Promise<void> | void;
-  private knownSynced: Set<string>;
+  private readonly onStateUpdate?: (knownSynced: Map<string, string>) => Promise<void> | void;
+  private readonly onConflict?: ConflictHandler;
+  private knownSynced: Map<string, string>;
 
   constructor(opts: SyncEngineOpts) {
     this.client = opts.client;
@@ -68,7 +109,8 @@ export class SyncEngine {
     this.masterKey = opts.masterKey;
     this.onStatusChange = opts.onStatusChange;
     this.onStateUpdate = opts.onStateUpdate;
-    this.knownSynced = new Set(opts.knownSynced ?? []);
+    this.onConflict = opts.onConflict;
+    this.knownSynced = new Map(opts.knownSynced ?? []);
   }
 
   async sync(): Promise<void> {
@@ -100,33 +142,108 @@ export class SyncEngine {
       await this.manifest.load();
       const entries = this.manifest.getAllEntries();
 
+      const nextKnown = new Map<string, string>();
+
       for (const [path, entry] of entries) {
         const localExists = await this.vault.exists(path);
-        if (localExists) {
-          const local = await this.vault.readBinary(path);
-          const localHash = await sha256Hex(local);
-          if (localHash === entry.hash) continue;
-          const plaintext = await this.downloadAndDecrypt(entry);
-          await this.vault.modify(path, plaintext);
-        } else {
+
+        if (!localExists) {
+          // Server-only file → pull it down.
           const plaintext = await this.downloadAndDecrypt(entry);
           await this.vault.create(path, plaintext);
+          nextKnown.set(path, entry.hash);
+          continue;
+        }
+
+        const local = await this.vault.readBinary(path);
+        const localHash = await sha256Hex(local);
+
+        // Case 1: in sync.
+        if (localHash === entry.hash) {
+          nextKnown.set(path, entry.hash);
+          continue;
+        }
+
+        // Differs. Consult the three-point comparison to decide why.
+        const lastKnown = this.knownSynced.get(path);
+
+        // Case 2: no reliable history (never synced, or migration sentinel).
+        // Preserve local — record its actual hash so the next round has a real anchor.
+        // pushChanges() will upload the local copy if the user wants it pushed.
+        if (lastKnown === undefined || lastKnown === '') {
+          nextKnown.set(path, localHash);
+          continue;
+        }
+
+        // Case 3: local moved, server didn't → leave local alone, push will handle it.
+        if (lastKnown === entry.hash) {
+          nextKnown.set(path, localHash);
+          continue;
+        }
+
+        // Case 4: server moved, local didn't → download.
+        if (lastKnown === localHash) {
+          const plaintext = await this.downloadAndDecrypt(entry);
+          await this.vault.modify(path, plaintext);
+          nextKnown.set(path, entry.hash);
+          continue;
+        }
+
+        // Case 5: real divergence — both sides moved. Ask the handler.
+        const serverPlaintext = await this.downloadAndDecrypt(entry);
+        const resolution = await this.resolveConflict({
+          path,
+          localHash,
+          serverHash: entry.hash,
+          lastKnownHash: lastKnown,
+          localContent: local,
+          serverContent: serverPlaintext,
+          serverModifiedAt: entry.modifiedAt,
+        });
+
+        if (resolution === 'keep-local') {
+          nextKnown.set(path, localHash);
+        } else if (resolution === 'keep-server') {
+          await this.vault.modify(path, serverPlaintext);
+          nextKnown.set(path, entry.hash);
+        } else {
+          // keep-both: server copy saved alongside local with a suffix; local stays put.
+          const conflictPath = makeConflictCopyPath(path);
+          await this.vault.create(conflictPath, serverPlaintext);
+          nextKnown.set(path, localHash);
+          nextKnown.set(conflictPath, entry.hash);
         }
       }
 
-      for (const path of this.knownSynced) {
+      // Deletions: a path that was known-synced and is missing from the server manifest
+      // means the user (or another device) deleted it remotely. Mirror locally.
+      for (const path of this.knownSynced.keys()) {
         if (!entries.has(path) && (await this.vault.exists(path))) {
           await this.vault.delete(path);
         }
       }
 
-      this.knownSynced = new Set(entries.keys());
-      if (this.onStateUpdate) await this.onStateUpdate(new Set(this.knownSynced));
+      this.knownSynced = nextKnown;
+      if (this.onStateUpdate) await this.onStateUpdate(new Map(this.knownSynced));
       this.emit('idle');
     } catch (e) {
       this.emit('error', { errorMessage: e instanceof Error ? e.message : 'Unknown error' });
       throw e;
     }
+  }
+
+  private async resolveConflict(info: ConflictInfo): Promise<ConflictResolution> {
+    if (this.onConflict) {
+      return this.onConflict(info);
+    }
+    // No handler wired → fall back to server-wins, but flag it so the operator can
+    // tell it apart from the pre-LOC-47 silent-clobber bug.
+    console.warn(
+      `[silent-stone] conflict on ${info.path}: no handler wired, defaulting to keep-server. ` +
+        `local=${info.localHash.slice(0, 8)} server=${info.serverHash.slice(0, 8)} ` +
+        `lastKnown=${info.lastKnownHash.slice(0, 8)}`,
+    );
+    return 'keep-server';
   }
 
   private async downloadAndDecrypt(entry: ManifestEntry): Promise<ArrayBuffer> {
@@ -202,8 +319,12 @@ export class SyncEngine {
       const mutated = pendingSets.length > 0 || pendingDeletes.length > 0;
       if (mutated) {
         await this.saveWithRetry(pendingSets, pendingDeletes);
-        this.knownSynced = new Set(this.manifest.getAllEntries().keys());
-        if (this.onStateUpdate) await this.onStateUpdate(new Set(this.knownSynced));
+        // Rebuild knownSynced from the post-push manifest, preserving the per-path hash so
+        // the next sync round has a real anchor for divergence detection.
+        const next = new Map<string, string>();
+        for (const [p, e] of this.manifest.getAllEntries()) next.set(p, e.hash);
+        this.knownSynced = next;
+        if (this.onStateUpdate) await this.onStateUpdate(new Map(this.knownSynced));
       }
 
       this.watcher.clearQueue();

--- a/src/sync/known-synced.ts
+++ b/src/sync/known-synced.ts
@@ -1,0 +1,28 @@
+/**
+ * Read the persisted knownSynced blob and return it as a `Map<path, hash>`.
+ *
+ * Three input shapes we accept:
+ *   - Legacy `string[]` (pre-LOC-47): paths only. Hydrate every path with the
+ *     empty-string sentinel — the engine treats that as "no reliable history,
+ *     preserve local, record the real hash next round" so an upgrade across
+ *     plugin versions can't false-positive into a conflict storm.
+ *   - Current `Record<path, hash>` (post-LOC-47): JSON-safe serialization of
+ *     `Object.fromEntries(map)`. Round-trip into a Map.
+ *   - Missing / null / unknown shape: fresh empty Map.
+ *
+ * Lives in its own module (not main.ts) so it can be unit-tested without pulling
+ * in the `obsidian` runtime, which isn't bundled.
+ */
+export function hydrateKnownSynced(raw: unknown): Map<string, string> {
+  if (Array.isArray(raw)) {
+    return new Map(raw.filter((p): p is string => typeof p === 'string').map((p) => [p, '']));
+  }
+  if (raw && typeof raw === 'object') {
+    const m = new Map<string, string>();
+    for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+      if (typeof v === 'string') m.set(k, v);
+    }
+    return m;
+  }
+  return new Map();
+}


### PR DESCRIPTION
## Summary

Adds divergence-based conflict detection to `src/sync/engine.ts`. `pullChanges()` no longer silently overwrites local edits when the local plaintext hash differs from the manifest hash — it now distinguishes a real conflict (both sides changed since the last known-synced state) from a one-sided change.

The engine's `knownSynced` representation moves from a path-only `Set<string>` to a `Map<path, lastKnownPlaintextHash>` with a migration path for legacy `string[]` state in saved data. New module: `src/sync/known-synced.ts`. New test file: `src/__tests__/known-synced-migration.test.ts`.

**Linear:** [LOC-47 — Add divergence-based conflict detection to sync engine](https://linear.app/local-daily/issue/LOC-47/add-divergence-based-conflict-detection-to-sync-engine)
**Parent mission:** [LOC-46 — Mission: 2026-05-12 plugin](https://linear.app/local-daily/issue/LOC-46/mission-2026-05-12-plugin) (prereq for LOC-14, LOC-15, LOC-12)

## Why this lands first in the mission

LOC-14 (auto-sync file watcher) and LOC-15 (periodic sync interval) are about to start firing syncs without the user present — which turns silent clobbering from an edge case into a data-loss bug. LOC-12 (conflict resolution modal) has nothing to render without a real divergence signal. LOC-47 fixes the engine gap that unblocks all three.

## Flags for reviewer

- **Commit subject convention slip.** The commit `7a7cdee feat(sync): add divergence-based conflict detection to engine` does not carry the `(LOC-47)` suffix the project's convention prefers — the LOC-47 reference lives in the commit body instead. Operator opted not to amend. Decide whether to squash-merge with a corrected title.
- **Migration path not exercised end-to-end.** The legacy `vault.knownSynced: string[]` → `Map<path, hash>` migration is covered by unit tests (`known-synced-migration.test.ts`), but it has not been run against the real test vault's `data.json` yet. The test vault still holds the legacy shape. LOC-14 (next ticket in the mission) will trigger the migration for real once auto-sync starts firing on that vault. If anything is going to break the migration, that's where it surfaces.

## Test plan

- [x] `npm test` — 228/228 pass on rebased base
- [x] `npx tsc --noEmit` — clean on `src/` (vitest/vite transitive `.d.ts` noise filtered per CLAUDE.md)
- [x] `npm run lint` — 0 errors; 3 pre-existing `no-explicit-any` warnings in `src/ui/__tests__/setup-modal.test.ts`, untouched by this PR
- [ ] Reviewer: spot-check the migration path against a vault with legacy `string[]` shape (or wait for LOC-14 to exercise it for real)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Implements divergence-based conflict detection in the sync engine (LOC-47) to prevent silent data loss when local edits conflict with server changes. Replaces the path-only `knownSynced` tracking with per-path hash mapping to enable three-way divergence detection (local vs. server vs. lastKnown). Includes migration from legacy `string[]` format to the new `Map<path, hash>` structure.

## Core Changes

### Conflict Detection Architecture
- **SyncEngine divergence model**: Determines real conflicts via three-way comparison (local hash, server hash, lastKnownHash)
- **New conflict flow**: `pullChanges()` now calls `resolveConflict()` when divergence is detected, delegating to `onConflict` handler or defaulting to server-wins
- **New exports**:
  - `ConflictResolution`: 'keep-local' | 'keep-server' | 'keep-both'
  - `ConflictInfo`: path, localHash, serverHash, lastKnownHash, content values, serverModifiedAt
  - `ConflictHandler`: async handler signature for conflict decisions
  - `SyncEngineOpts.onConflict?: ConflictHandler`

### State Shape Upgrade
- `knownSynced`: `Set<string>` → `Map<string, string>` (path → lastKnownPlaintextHash)
- `onStateUpdate` callback signature updated to handle `Map` instead of `Set`

### Migration & Hydration
- **`hydrateKnownSynced()` function** (new `src/sync/known-synced.ts`):
  - Converts legacy `string[]` (paths-only) to `Map<path, "">` using empty-string sentinel
  - Converts modern `Record<path, hash>` to `Map<path, hash>`
  - Gracefully handles invalid input (returns empty `Map`)
- **Integration in `main.ts`**: Vault initialization now hydrates persisted state via `hydrateKnownSynced()` and persists updates as `Object.fromEntries(map)`

### Conflict Resolution Implementation
- **keep-local**: Preserves local file, updates `knownSynced` to local hash
- **keep-server**: Overwrites local with server content, updates `knownSynced` to server hash
- **keep-both**: Writes server content as conflict copy (filename: `<name> (conflict copy <iso>).<ext>`), preserves local, tracks both hashes
- **Default strategy** (`ask`): Falls back to `keep-server` with a Notice until interactive modal lands

### Post-Push Sync State
- `pushChanges()` now reconstructs `knownSynced: Map<path, plaintext-SHA256>` from manifest, providing hash anchors for subsequent pulls

## Test Coverage
- **Migration tests** (10 cases): Legacy array, modern Record, invalid inputs, sentinel behavior
- **Engine tests** (+11 new): One-sided divergence, real conflicts, all resolution paths, default behavior, push-state reconstruction
- **Total**: 228 passing tests, tsc clean, 0 lint errors

## Known Limitations & Follow-up
- One commit subject lacks "(LOC-47)" suffix (squash-merge optional)
- Migration tested in isolation; real vault data.json exercise deferred to LOC-14
- Interactive conflict modal deferred; `ask` strategy currently shows Notice + defaults to `keep-server`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josemoreno801-netizen/silent-stone-obsidian/pull/34)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->