### PR TITLE
feat(sync): wire auto-sync file watcher controller (LOC-14)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import type { WrappedKey } from './crypto/types';
 import { ManifestManager } from './sync/manifest';
 import { FileWatcher } from './sync/watcher';
 import { SyncEngine, type ConflictHandler, type ConflictResolution } from './sync/engine';
+import { AutoSyncController } from './sync/auto-sync';
 import { hydrateKnownSynced } from './sync/known-synced';
 import { compileIgnorePrefixes, isIgnored } from './sync/ignore';
 import { LoginModal } from './ui/login-modal';
@@ -45,6 +46,7 @@ export default class SilentStoneSyncPlugin extends Plugin {
   vaultClient: VaultClient | null = null;
   private vaultEngine: SyncEngine | null = null;
   private vaultKey: Uint8Array | null = null;
+  private vaultAutoSync: AutoSyncController | null = null;
 
   // ── Trust-the-sync (v0.1.7) ───────────────────────
   /** Last-known metrics from a successful sync, restored on plugin reload. */
@@ -154,8 +156,9 @@ export default class SilentStoneSyncPlugin extends Plugin {
       });
     }
 
-    // TODO: Register vault file watchers for auto-sync
-    // TODO: Set up periodic sync interval
+    // TODO: Set up periodic sync interval (LOC-? sibling ticket).
+    // The vault file watcher + auto-sync trigger are wired in armVaultRuntime()
+    // because they require an unlocked master key.
   }
 
   onunload(): void {
@@ -389,6 +392,11 @@ export default class SilentStoneSyncPlugin extends Plugin {
     const manifest = new ManifestManager(vaultClient, masterKey);
     const watcher = new FileWatcher(this, this.app.vault, {
       ignorePaths: this.settings.ignorePaths,
+      // Lazy closure — the controller field is assigned later in this function.
+      // Resolving `this.vaultAutoSync` at call time means the first onSettle
+      // can't fire until the watcher's per-path debounce window (default 2s)
+      // expires, by which point the controller exists.
+      onSettle: () => this.vaultAutoSync?.notify(),
     });
     watcher.start();
 
@@ -450,8 +458,15 @@ export default class SilentStoneSyncPlugin extends Plugin {
       },
     });
 
+    const autoSync = new AutoSyncController({
+      engine,
+      onError: (err) => console.warn('[silent-stone] auto-sync failed:', err),
+    });
+    if (this.settings.autoSync) autoSync.start();
+
     this.vaultClient = vaultClient;
     this.vaultEngine = engine;
+    this.vaultAutoSync = autoSync;
     this.vaultKey = masterKey;
     this.status = 'idle';
     this.updateStatusBar();
@@ -481,6 +496,8 @@ export default class SilentStoneSyncPlugin extends Plugin {
 
   lockVault(): void {
     if (this.vaultKey) this.vaultKey.fill(0);
+    this.vaultAutoSync?.stop();
+    this.vaultAutoSync = null;
     this.vaultClient = null;
     this.vaultEngine = null;
     this.vaultKey = null;
@@ -503,6 +520,8 @@ export default class SilentStoneSyncPlugin extends Plugin {
   async logoutVault(): Promise<void> {
     // In-memory teardown — mirrors lockVault, but no Notice (we show our own).
     if (this.vaultKey) this.vaultKey.fill(0);
+    this.vaultAutoSync?.stop();
+    this.vaultAutoSync = null;
     this.vaultClient = null;
     this.vaultEngine = null;
     this.vaultKey = null;
@@ -535,6 +554,18 @@ export default class SilentStoneSyncPlugin extends Plugin {
       const msg = e instanceof Error ? e.message : 'Unknown error';
       new Notice(`Vault sync failed: ${msg}`);
     }
+  }
+
+  /**
+   * Start or stop the auto-sync controller. No-op when the vault is locked
+   * (controller is null until armVaultRuntime constructs it); the persisted
+   * `settings.autoSync` flag is consulted on the next unlock so the toggle
+   * state survives a lock/unlock round-trip.
+   */
+  setAutoSyncEnabled(value: boolean): void {
+    if (!this.vaultAutoSync) return;
+    if (value) this.vaultAutoSync.start();
+    else this.vaultAutoSync.stop();
   }
 
   private async checkConnection(): Promise<void> {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -204,6 +204,7 @@ export class SilentStoneSyncSettingTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.autoSync).onChange(async (value) => {
           this.plugin.settings.autoSync = value;
           await this.plugin.saveSettings();
+          this.plugin.setAutoSyncEnabled(value);
         }),
       );
 

--- a/src/sync/__tests__/auto-sync.test.ts
+++ b/src/sync/__tests__/auto-sync.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  AutoSyncController,
+  type AutoSyncTrigger,
+} from '../auto-sync';
+
+/**
+ * Build a minimal AutoSyncTrigger backed by a vi.fn().
+ * The controller depends on the structural interface, not SyncEngine,
+ * so no API client, manifest, or Obsidian shim is needed.
+ */
+function makeEngine(): { engine: AutoSyncTrigger; sync: ReturnType<typeof vi.fn> } {
+  const sync = vi.fn().mockResolvedValue(undefined);
+  return { engine: { sync }, sync };
+}
+
+/**
+ * Build an engine whose sync() returns a manually-resolvable promise on the
+ * first call. Used to model a sync that is "in-flight" while the controller
+ * receives further notify() calls. Subsequent calls resolve immediately.
+ */
+function makeDeferredEngine(): {
+  engine: AutoSyncTrigger;
+  sync: ReturnType<typeof vi.fn>;
+  resolveFirst: () => void;
+} {
+  let resolveFirst: () => void = () => {};
+  const sync = vi
+    .fn()
+    .mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFirst = resolve;
+        }),
+    )
+    .mockResolvedValue(undefined);
+  return { engine: { sync }, sync, resolveFirst: () => resolveFirst() };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('AutoSyncController — basic dispatch', () => {
+  it('fires sync once after a single notify and the debounce window', async () => {
+    const { engine, sync } = makeEngine();
+    const ctrl = new AutoSyncController({ engine });
+    ctrl.start();
+
+    ctrl.notify();
+    expect(sync).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(sync).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces rapid notifies into a single sync', async () => {
+    const { engine, sync } = makeEngine();
+    const ctrl = new AutoSyncController({ engine });
+    ctrl.start();
+
+    for (let i = 0; i < 5; i++) {
+      ctrl.notify();
+      await vi.advanceTimersByTimeAsync(100);
+    }
+
+    expect(sync).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(sync).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects a custom debounceMs', async () => {
+    const { engine, sync } = makeEngine();
+    const ctrl = new AutoSyncController({ engine, debounceMs: 1000 });
+    ctrl.start();
+
+    ctrl.notify();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(sync).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(sync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AutoSyncController — start / stop gating', () => {
+  it('ignores notify before start()', async () => {
+    const { engine, sync } = makeEngine();
+    const ctrl = new AutoSyncController({ engine });
+
+    ctrl.notify();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(sync).not.toHaveBeenCalled();
+  });
+
+  it('detaches on stop() — pending notifies do not fire after toggle off', async () => {
+    const { engine, sync } = makeEngine();
+    const ctrl = new AutoSyncController({ engine });
+    ctrl.start();
+
+    ctrl.notify();
+    ctrl.stop();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(sync).not.toHaveBeenCalled();
+  });
+
+  it('re-arms after stop() → start() — new notifies still fire', async () => {
+    const { engine, sync } = makeEngine();
+    const ctrl = new AutoSyncController({ engine });
+
+    ctrl.start();
+    ctrl.notify();
+    ctrl.stop();
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(sync).not.toHaveBeenCalled();
+
+    ctrl.start();
+    ctrl.notify();
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(sync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AutoSyncController — in-flight re-entry guard', () => {
+  it('fires a second sync if notify arrives during an in-flight sync', async () => {
+    const { engine, sync, resolveFirst } = makeDeferredEngine();
+    const ctrl = new AutoSyncController({ engine });
+    ctrl.start();
+
+    ctrl.notify();
+    await vi.advanceTimersByTimeAsync(500);
+    // First sync is now in-flight, awaiting on the deferred promise.
+    expect(sync).toHaveBeenCalledTimes(1);
+
+    // Notify during in-flight — should set the pending flag, not start a new sync yet.
+    ctrl.notify();
+    expect(sync).toHaveBeenCalledTimes(1);
+
+    // Resolve the first sync. The controller's finally block should re-schedule.
+    resolveFirst();
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(sync).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not fire a late sync if stop() is called while in-flight with pending=true', async () => {
+    const { engine, sync, resolveFirst } = makeDeferredEngine();
+    const ctrl = new AutoSyncController({ engine });
+    ctrl.start();
+
+    ctrl.notify();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(sync).toHaveBeenCalledTimes(1);
+
+    // Set pending, then disarm before the in-flight resolves.
+    ctrl.notify();
+    ctrl.stop();
+
+    resolveFirst();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    // Only the original in-flight sync ran. No follow-up.
+    expect(sync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AutoSyncController — error handling', () => {
+  it('forwards sync rejections to onError and does not enter a retry loop', async () => {
+    const error = new Error('boom');
+    const sync = vi.fn().mockRejectedValue(error);
+    const onError = vi.fn();
+    const ctrl = new AutoSyncController({ engine: { sync }, onError });
+    ctrl.start();
+
+    ctrl.notify();
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(sync).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(error);
+
+    // Generously give the clock more room — controller must NOT auto-retry on its own.
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(sync).toHaveBeenCalledTimes(1);
+  });
+
+  it('survives a rejected sync — subsequent notifies still fire', async () => {
+    const error = new Error('boom');
+    const sync = vi
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValue(undefined);
+    const onError = vi.fn();
+    const ctrl = new AutoSyncController({ engine: { sync }, onError });
+    ctrl.start();
+
+    ctrl.notify();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(sync).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    ctrl.notify();
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(sync).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/sync/__tests__/watcher.test.ts
+++ b/src/sync/__tests__/watcher.test.ts
@@ -208,3 +208,61 @@ describe('FileWatcher — queue drain', () => {
     ]);
   });
 });
+
+describe('FileWatcher — onSettle hook', () => {
+  it('fires onSettle after a path settles into the queue', () => {
+    const vault = new FakeVault();
+    const onSettle = vi.fn();
+    const watcher = new FileWatcher(new FakePlugin(), vault, { onSettle });
+    watcher.start();
+
+    vault.emit('modify', makeFile('note.md'));
+    expect(onSettle).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(2000);
+
+    expect(onSettle).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onSettle once per path-settle, not once globally', () => {
+    const vault = new FakeVault();
+    const onSettle = vi.fn();
+    const watcher = new FileWatcher(new FakePlugin(), vault, { onSettle });
+    watcher.start();
+
+    vault.emit('modify', makeFile('a.md'));
+    vault.emit('modify', makeFile('b.md'));
+    vi.advanceTimersByTime(2000);
+
+    expect(onSettle).toHaveBeenCalledTimes(2);
+  });
+
+  it('coalesces rapid same-path emits — onSettle fires once', () => {
+    const vault = new FakeVault();
+    const onSettle = vi.fn();
+    const watcher = new FileWatcher(new FakePlugin(), vault, { onSettle });
+    watcher.start();
+
+    vault.emit('modify', makeFile('note.md'));
+    vi.advanceTimersByTime(500);
+    vault.emit('modify', makeFile('note.md'));
+    vi.advanceTimersByTime(500);
+    vault.emit('modify', makeFile('note.md'));
+    vi.advanceTimersByTime(2000);
+
+    expect(onSettle).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire onSettle for ignored paths', () => {
+    const vault = new FakeVault();
+    const onSettle = vi.fn();
+    const watcher = new FileWatcher(new FakePlugin(), vault, { onSettle });
+    watcher.start();
+
+    vault.emit('modify', makeFile('.obsidian/workspace.json'));
+    vault.emit('modify', makeFile('.trash/deleted.md'));
+    vi.advanceTimersByTime(2000);
+
+    expect(onSettle).not.toHaveBeenCalled();
+  });
+});

--- a/src/sync/auto-sync.ts
+++ b/src/sync/auto-sync.ts
@@ -1,0 +1,108 @@
+/**
+ * Auto-sync controller. Sits between the FileWatcher and the SyncEngine,
+ * owning the *trigger policy* — when to fire a sync, when to coalesce, and
+ * when to skip because one is already in flight.
+ *
+ * The watcher debounces vault events per-path (2s default). Each settled
+ * path-event calls `notify()`. The controller applies its own short debounce
+ * (500ms default) so simultaneous multi-file settles produce one sync trigger
+ * instead of one per file.
+ *
+ * Lifecycle is gated by `start()` / `stop()` — toggling auto-sync off detaches
+ * the controller but leaves the watcher running, so the queue keeps capturing
+ * changes and a manual sync still picks them up.
+ */
+
+/**
+ * Minimal structural type the controller needs from the sync engine.
+ * `SyncEngine` satisfies this — using a narrow interface keeps tests free of
+ * Obsidian, API client, and manifest mocks.
+ */
+export interface AutoSyncTrigger {
+  sync(): Promise<void>;
+}
+
+export interface AutoSyncControllerOpts {
+  engine: AutoSyncTrigger;
+  /** Debounce window applied on top of the watcher's per-path debounce. Default 500ms. */
+  debounceMs?: number;
+  /** Called when `engine.sync()` rejects. Never rethrown from the controller. */
+  onError?: (err: unknown) => void;
+}
+
+const DEFAULT_DEBOUNCE_MS = 500;
+
+export class AutoSyncController {
+  private readonly engine: AutoSyncTrigger;
+  private readonly debounceMs: number;
+  private readonly onError?: (err: unknown) => void;
+
+  private active = false;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private inProgress = false;
+  /** Set when notify() arrives during an in-flight sync. Drains in fire()'s finally block. */
+  private pending = false;
+
+  constructor(opts: AutoSyncControllerOpts) {
+    this.engine = opts.engine;
+    this.debounceMs = opts.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+    this.onError = opts.onError;
+  }
+
+  /** Arm the controller. Subsequent notify() calls schedule syncs. */
+  start(): void {
+    this.active = true;
+  }
+
+  /**
+   * Disarm. Clears any scheduled timer and drops the pending flag so a
+   * sync that finishes after stop() does not enqueue another round.
+   */
+  stop(): void {
+    this.active = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.pending = false;
+  }
+
+  /**
+   * Called by the watcher when a path's per-path debounce settles.
+   * During an in-flight sync this just sets a pending flag — the in-flight
+   * sync's finally block re-schedules. Otherwise it resets the debounce timer.
+   */
+  notify(): void {
+    if (!this.active) return;
+
+    if (this.inProgress) {
+      this.pending = true;
+      return;
+    }
+
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      void this.fire();
+    }, this.debounceMs);
+  }
+
+  private async fire(): Promise<void> {
+    this.timer = null;
+    if (!this.active) return;
+
+    this.inProgress = true;
+    try {
+      await this.engine.sync();
+    } catch (err) {
+      this.onError?.(err);
+    } finally {
+      this.inProgress = false;
+      if (this.pending && this.active) {
+        this.pending = false;
+        this.timer = setTimeout(() => {
+          void this.fire();
+        }, this.debounceMs);
+      }
+    }
+  }
+}

--- a/src/sync/watcher.ts
+++ b/src/sync/watcher.ts
@@ -31,6 +31,12 @@ export interface FileWatcherOptions {
   ignorePaths?: string[];
   /** Debounce window in ms. Defaults to 2000. */
   debounceMs?: number;
+  /**
+   * Called every time a path's per-path debounce expires and the event lands
+   * in the settled queue. Used by the auto-sync controller to schedule syncs;
+   * never invoked for ignored paths or for events still in the pending window.
+   */
+  onSettle?: () => void;
 }
 
 const DEFAULT_DEBOUNCE_MS = 2000;
@@ -42,6 +48,7 @@ const DEFAULT_DEBOUNCE_MS = 2000;
 export class FileWatcher {
   private readonly ignorePrefixes: string[];
   private readonly debounceMs: number;
+  private readonly onSettle?: () => void;
   private pending: Map<string, { event: ChangeEvent; timer: ReturnType<typeof setTimeout> }> =
     new Map();
   private queue: Map<string, ChangeEvent> = new Map();
@@ -53,6 +60,7 @@ export class FileWatcher {
   ) {
     this.ignorePrefixes = compileIgnorePrefixes(opts.ignorePaths);
     this.debounceMs = opts.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+    this.onSettle = opts.onSettle;
   }
 
   start(): void {
@@ -89,6 +97,7 @@ export class FileWatcher {
     const timer = setTimeout(() => {
       this.queue.set(event.path, event);
       this.pending.delete(event.path);
+      this.onSettle?.();
     }, this.debounceMs);
 
     this.pending.set(event.path, { event, timer });


### PR DESCRIPTION
Vault edits now trigger a sync ~2.5s after the last keystroke; the auto-sync
toggle starts and stops the trigger without losing queued changes.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Tactical Integration of Auto-Sync File Watcher Controller

### Operational Deployment
The plugin now deploys an `AutoSyncController` as the core engine for vault auto-sync operations, wired to the unlocked runtime state. The controller maintains defensive positioning with explicit start/stop lifecycle gating—auto-sync stands down when vault is locked or user is logged out.

### Command Structure & Integration Points
- **Main Command Post** (`src/main.ts`): Establishes the `vaultAutoSync` field to hold the controller instance. File watcher's `onSettle` callback routes intelligence directly to the controller's `notify()` method via `() => this.vaultAutoSync?.notify()`. New public method `setAutoSyncEnabled(value: boolean)` provides command authority to toggle operations.
- **Settings Control** (`src/settings.ts`): Auto-sync toggle now executes immediate operational effect via `setAutoSyncEnabled()` after persisting the setting.
- **Field Reconnaissance** (`src/sync/watcher.ts`): FileWatcher accepts optional `onSettle` callback to report when per-path debounce settles, filtering out ignored zones (`.obsidian/`, `.trash/`).

### Operational Layers
The controller implements **dual-layer debounce** architecture:
1. **Watcher layer**: Per-path debounce (2s default)
2. **Controller layer**: Coalesced dispatch (500ms default) to merge simultaneous multi-file changes into single sync trigger

Debounce logic enforces `notify()` → `fire()` pipeline with in-flight re-entry handling: `pending` flag queues a follow-up sync after current operation completes, preventing lost changes and retry loops.

### Defensive Measures
- Lifecycle gating via `start()`/`stop()`: `stop()` clears timers and blocks re-entry, ensuring stopped controller cannot enqueue syncs
- Error handling swallows sync failures via optional `onError` callback (logs to console)
- Stopped controller clears pending flag to prevent re-escalation after stop signal
- No retry loop after rejected syncs—next keystroke triggers fresh dispatch
- Resolver function in watcher callback `() => this.vaultAutoSync?.notify()` ensures controller exists before first settlement fires

### Supporting Infrastructure
- **Test Coverage** (`src/sync/__tests__/`): 218 lines covering debounce gating, start/stop behavior, in-flight re-entry, error propagation, and watcher settlement callbacks across two test suites
- **New Exported Contracts**: `AutoSyncTrigger` interface (minimal engine contract), `AutoSyncControllerOpts` configuration interface, `AutoSyncController` class

**Lines Changed**: +410/-2 across 5 files | **Code Review Effort**: Medium

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josemoreno801-netizen/silent-stone-obsidian/pull/35)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->