### PR TITLE
josemoreno801/loc 15 wire periodic sync interval executor

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import { ManifestManager } from './sync/manifest';
 import { FileWatcher } from './sync/watcher';
 import { SyncEngine, type ConflictHandler, type ConflictResolution } from './sync/engine';
 import { AutoSyncController } from './sync/auto-sync';
+import { PeriodicSyncController } from './sync/periodic-sync';
 import { hydrateKnownSynced } from './sync/known-synced';
 import { compileIgnorePrefixes, isIgnored } from './sync/ignore';
 import { LoginModal } from './ui/login-modal';
@@ -47,6 +48,7 @@ export default class SilentStoneSyncPlugin extends Plugin {
   private vaultEngine: SyncEngine | null = null;
   private vaultKey: Uint8Array | null = null;
   private vaultAutoSync: AutoSyncController | null = null;
+  private vaultPeriodicSync: PeriodicSyncController | null = null;
 
   // ── Trust-the-sync (v0.1.7) ───────────────────────
   /** Last-known metrics from a successful sync, restored on plugin reload. */
@@ -156,13 +158,16 @@ export default class SilentStoneSyncPlugin extends Plugin {
       });
     }
 
-    // TODO: Set up periodic sync interval (LOC-? sibling ticket).
-    // The vault file watcher + auto-sync trigger are wired in armVaultRuntime()
-    // because they require an unlocked master key.
+    // The vault file watcher, auto-sync trigger, and periodic-sync timer are
+    // wired in armVaultRuntime() because they all require an unlocked master key.
   }
 
   onunload(): void {
-    // Obsidian handles cleanup of registered events/commands automatically
+    // Obsidian auto-cleans registerEvent/addCommand/etc, but not the self-managed
+    // setTimeout/setInterval inside our sync controllers — stop them explicitly
+    // so neither fires after the plugin is disabled.
+    this.vaultAutoSync?.stop();
+    this.vaultPeriodicSync?.stop();
   }
 
   async loadSettings(): Promise<void> {
@@ -464,9 +469,16 @@ export default class SilentStoneSyncPlugin extends Plugin {
     });
     if (this.settings.autoSync) autoSync.start();
 
+    const periodicSync = new PeriodicSyncController({
+      engine,
+      onError: (err) => console.warn('[silent-stone] periodic sync failed:', err),
+    });
+    if (this.settings.autoSync) periodicSync.start(this.settings.syncInterval * 60_000);
+
     this.vaultClient = vaultClient;
     this.vaultEngine = engine;
     this.vaultAutoSync = autoSync;
+    this.vaultPeriodicSync = periodicSync;
     this.vaultKey = masterKey;
     this.status = 'idle';
     this.updateStatusBar();
@@ -498,6 +510,8 @@ export default class SilentStoneSyncPlugin extends Plugin {
     if (this.vaultKey) this.vaultKey.fill(0);
     this.vaultAutoSync?.stop();
     this.vaultAutoSync = null;
+    this.vaultPeriodicSync?.stop();
+    this.vaultPeriodicSync = null;
     this.vaultClient = null;
     this.vaultEngine = null;
     this.vaultKey = null;
@@ -522,6 +536,8 @@ export default class SilentStoneSyncPlugin extends Plugin {
     if (this.vaultKey) this.vaultKey.fill(0);
     this.vaultAutoSync?.stop();
     this.vaultAutoSync = null;
+    this.vaultPeriodicSync?.stop();
+    this.vaultPeriodicSync = null;
     this.vaultClient = null;
     this.vaultEngine = null;
     this.vaultKey = null;
@@ -557,15 +573,31 @@ export default class SilentStoneSyncPlugin extends Plugin {
   }
 
   /**
-   * Start or stop the auto-sync controller. No-op when the vault is locked
-   * (controller is null until armVaultRuntime constructs it); the persisted
-   * `settings.autoSync` flag is consulted on the next unlock so the toggle
-   * state survives a lock/unlock round-trip.
+   * Start or stop both auto-sync controllers (file watcher + periodic interval).
+   * No-op when the vault is locked (controllers are null until armVaultRuntime
+   * constructs them); the persisted `settings.autoSync` flag is consulted on the
+   * next unlock so the toggle state survives a lock/unlock round-trip.
    */
   setAutoSyncEnabled(value: boolean): void {
-    if (!this.vaultAutoSync) return;
-    if (value) this.vaultAutoSync.start();
-    else this.vaultAutoSync.stop();
+    if (this.vaultAutoSync) {
+      if (value) this.vaultAutoSync.start();
+      else this.vaultAutoSync.stop();
+    }
+    if (this.vaultPeriodicSync) {
+      if (value) this.vaultPeriodicSync.start(this.settings.syncInterval * 60_000);
+      else this.vaultPeriodicSync.stop();
+    }
+  }
+
+  /**
+   * Update the periodic-sync cadence. No-op when the vault is locked or
+   * auto-sync is disabled — the persisted `settings.syncInterval` is picked up
+   * on the next unlock or auto-sync toggle.
+   */
+  setPeriodicSyncInterval(minutes: number): void {
+    if (!this.vaultPeriodicSync) return;
+    if (!this.settings.autoSync) return;
+    this.vaultPeriodicSync.setIntervalMs(minutes * 60_000);
   }
 
   private async checkConnection(): Promise<void> {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -219,6 +219,7 @@ export class SilentStoneSyncSettingTab extends PluginSettingTab {
           .onChange(async (value) => {
             this.plugin.settings.syncInterval = value;
             await this.plugin.saveSettings();
+            this.plugin.setPeriodicSyncInterval(value);
           }),
       );
 

--- a/src/sync/__tests__/periodic-sync.test.ts
+++ b/src/sync/__tests__/periodic-sync.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  PeriodicSyncController,
+  type PeriodicSyncTrigger,
+} from '../periodic-sync';
+
+function makeEngine(): { engine: PeriodicSyncTrigger; sync: ReturnType<typeof vi.fn> } {
+  const sync = vi.fn().mockResolvedValue(undefined);
+  return { engine: { sync }, sync };
+}
+
+function makeDeferredEngine(): {
+  engine: PeriodicSyncTrigger;
+  sync: ReturnType<typeof vi.fn>;
+  resolveFirst: () => void;
+} {
+  let resolveFirst: () => void = () => {};
+  const sync = vi
+    .fn()
+    .mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFirst = resolve;
+        }),
+    )
+    .mockResolvedValue(undefined);
+  return { engine: { sync }, sync, resolveFirst: () => resolveFirst() };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('PeriodicSyncController — basic dispatch', () => {
+  it('does not fire before start()', async () => {
+    const { engine, sync } = makeEngine();
+    new PeriodicSyncController({ engine });
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(sync).not.toHaveBeenCalled();
+  });
+
+  it('fires sync once per interval after start()', async () => {
+    const { engine, sync } = makeEngine();
+    const ctrl = new PeriodicSyncController({ engine });
+
+    ctrl.start(1_000);
+
+    expect(sync).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sync).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sync).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sync).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('PeriodicSyncController — start / stop gating', () => {
+  it('stop() clears the interval; no further syncs', async () => {
+    const { engine, sync } = makeEngine();
+    const ctrl = new PeriodicSyncController({ engine });
+
+    ctrl.start(1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sync).toHaveBeenCalledTimes(1);
+
+    ctrl.stop();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(sync).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-arms after stop() → start() — new interval fires', async () => {
+    const { engine, sync } = makeEngine();
+    const ctrl = new PeriodicSyncController({ engine });
+
+    ctrl.start(1_000);
+    ctrl.stop();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(sync).not.toHaveBeenCalled();
+
+    ctrl.start(500);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(sync).toHaveBeenCalledTimes(1);
+  });
+
+  it('start() while already active replaces the existing timer', async () => {
+    const { engine, sync } = makeEngine();
+    const ctrl = new PeriodicSyncController({ engine });
+
+    ctrl.start(1_000);
+    await vi.advanceTimersByTimeAsync(500); // partway through original tick
+
+    ctrl.start(2_000); // restart with new interval, drop pending tick
+
+    await vi.advanceTimersByTimeAsync(500); // original would have fired here
+    expect(sync).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1_500); // 2s total since restart
+    expect(sync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('PeriodicSyncController — settings change via setIntervalMs', () => {
+  it('setIntervalMs while active restarts the interval at the new cadence', async () => {
+    const { engine, sync } = makeEngine();
+    const ctrl = new PeriodicSyncController({ engine });
+
+    ctrl.start(1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sync).toHaveBeenCalledTimes(1);
+
+    ctrl.setIntervalMs(500);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(sync).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(sync).toHaveBeenCalledTimes(3);
+  });
+
+  it('setIntervalMs while stopped does not start the timer', async () => {
+    const { engine, sync } = makeEngine();
+    const ctrl = new PeriodicSyncController({ engine });
+
+    ctrl.setIntervalMs(500);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(sync).not.toHaveBeenCalled();
+  });
+});
+
+describe('PeriodicSyncController — in-flight re-entry guard', () => {
+  it('skips a tick if the previous sync is still running', async () => {
+    const { engine, sync, resolveFirst } = makeDeferredEngine();
+    const ctrl = new PeriodicSyncController({ engine });
+
+    ctrl.start(1_000);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sync).toHaveBeenCalledTimes(1); // first tick: in flight
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sync).toHaveBeenCalledTimes(1); // second tick: skipped, first still pending
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sync).toHaveBeenCalledTimes(1); // third tick: still skipped
+
+    resolveFirst();
+    await vi.advanceTimersByTimeAsync(0); // let the finally block run
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sync).toHaveBeenCalledTimes(2); // next tick after resolution: fires
+  });
+});
+
+describe('PeriodicSyncController — error handling', () => {
+  it('forwards sync rejections to onError and continues ticking', async () => {
+    const error = new Error('boom');
+    const sync = vi
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValue(undefined);
+    const onError = vi.fn();
+    const ctrl = new PeriodicSyncController({ engine: { sync }, onError });
+
+    ctrl.start(1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(sync).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(error);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sync).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/sync/periodic-sync.ts
+++ b/src/sync/periodic-sync.ts
@@ -1,0 +1,72 @@
+/**
+ * Periodic sync controller. Owns a repeating timer that calls `engine.sync()`
+ * every `intervalMs` milliseconds. Skips the tick if a sync is already in
+ * flight (no overlap). Lifecycle is `start(intervalMs)` / `stop()` —
+ * `setIntervalMs(ms)` is a convenience for changing cadence without losing
+ * the in-progress flag.
+ *
+ * Mirrors `AutoSyncController` (LOC-14): same structural engine interface,
+ * same onError contract, same "controller never throws" guarantee.
+ */
+
+export interface PeriodicSyncTrigger {
+  sync(): Promise<void>;
+}
+
+export interface PeriodicSyncControllerOpts {
+  engine: PeriodicSyncTrigger;
+  /** Called when `engine.sync()` rejects. Never rethrown from the controller. */
+  onError?: (err: unknown) => void;
+}
+
+export class PeriodicSyncController {
+  private readonly engine: PeriodicSyncTrigger;
+  private readonly onError?: (err: unknown) => void;
+
+  private active = false;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private inProgress = false;
+
+  constructor(opts: PeriodicSyncControllerOpts) {
+    this.engine = opts.engine;
+    this.onError = opts.onError;
+  }
+
+  /** Arm the controller and begin firing every `intervalMs`. Replaces any existing timer. */
+  start(intervalMs: number): void {
+    this.stop();
+    this.active = true;
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, intervalMs);
+  }
+
+  /** Disarm. Clears the interval. A sync already in-flight finishes naturally. */
+  stop(): void {
+    this.active = false;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** Change cadence. No-op when stopped — plugin re-reads settings on next start(). */
+  setIntervalMs(intervalMs: number): void {
+    if (!this.active) return;
+    this.start(intervalMs);
+  }
+
+  private async tick(): Promise<void> {
+    if (!this.active) return;
+    if (this.inProgress) return;
+
+    this.inProgress = true;
+    try {
+      await this.engine.sync();
+    } catch (err) {
+      this.onError?.(err);
+    } finally {
+      this.inProgress = false;
+    }
+  }
+}


### PR DESCRIPTION
- **feat(sync): add PeriodicSyncController with dispatch, gating, in-flight, error tests (LOC-15)**
- **feat(sync): wire PeriodicSyncController into plugin lifecycle (LOC-15)**
- **feat(settings): re-register periodic sync on slider change (LOC-15)**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Periodic Sync Controller Implementation

Added `PeriodicSyncController` class (`src/sync/periodic-sync.ts`) that manages a repeating timer for executing vault syncs at a configurable interval. The controller:
- Exposes `start(intervalMs)` to arm the timer and `stop()` to disarm it
- Prevents concurrent sync execution via an `inProgress` flag that gates ticks
- Supports dynamic interval updates via `setIntervalMs(ms)` when active
- Handles sync errors through an optional `onError` callback without halting subsequent ticks
- Implements two interfaces: `PeriodicSyncTrigger` (sync engine contract) and `PeriodicSyncControllerOpts` (constructor options)

Comprehensive test coverage (`src/sync/__tests__/periodic-sync.test.ts`) validates dispatch timing, start/stop lifecycle, re-arming, timer replacement, interval changes, in-flight gating, and error handling.

## Plugin Lifecycle Integration

Modified `src/main.ts` to instantiate and manage `PeriodicSyncController` alongside the existing `AutoSyncController`:
- Constructor creates `vaultPeriodicSync` when `settings.autoSync` is enabled
- `setAutoSyncEnabled()` now controls both controllers (periodic controller starts with `settings.syncInterval * 60_000`)
- Teardown wiring added to `lockVault()`, `logoutVault()`, and `onunload()` to explicitly stop periodic controller

Added new public method `setPeriodicSyncInterval(minutes: number)` that updates the periodic controller's interval; no-ops when vault is locked or auto-sync is disabled.

## Settings Integration

Modified `src/settings.ts` to call `this.plugin.setPeriodicSyncInterval(value)` when the sync interval slider changes, ensuring the periodic controller's cadence is updated immediately on settings adjustment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josemoreno801-netizen/silent-stone-obsidian/pull/36)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->