### PR TITLE
feat(sync): add conflict resolution modal for ask strategy (LOC-12)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,15 +18,20 @@ import {
 import type { WrappedKey } from './crypto/types';
 import { ManifestManager } from './sync/manifest';
 import { FileWatcher } from './sync/watcher';
-import { SyncEngine, type ConflictHandler, type ConflictResolution } from './sync/engine';
+import { SyncEngine, type ConflictHandler } from './sync/engine';
 import { AutoSyncController } from './sync/auto-sync';
 import { PeriodicSyncController } from './sync/periodic-sync';
 import { hydrateKnownSynced } from './sync/known-synced';
 import { compileIgnorePrefixes, isIgnored } from './sync/ignore';
+import {
+  createConflictHandler,
+  type ConflictHandlerWithReset,
+} from './sync/conflict-handler';
 import { LoginModal } from './ui/login-modal';
 import { LogoutModal } from './ui/logout-modal';
 import { SetupModal } from './ui/setup-modal';
 import { UnlockModal } from './ui/unlock-modal';
+import { ConflictModal, type ConflictModalChoice } from './ui/sync-modal';
 
 const KNOWN_SYNCED_KEY = 'vault.knownSynced';
 const SYNC_METRICS_KEY = 'vault.syncMetrics';
@@ -49,6 +54,7 @@ export default class SilentStoneSyncPlugin extends Plugin {
   private vaultKey: Uint8Array | null = null;
   private vaultAutoSync: AutoSyncController | null = null;
   private vaultPeriodicSync: PeriodicSyncController | null = null;
+  private vaultConflictHandler: ConflictHandlerWithReset | null = null;
 
   // ── Trust-the-sync (v0.1.7) ───────────────────────
   /** Last-known metrics from a successful sync, restored on plugin reload. */
@@ -436,6 +442,14 @@ export default class SilentStoneSyncPlugin extends Plugin {
       knownSynced,
       onConflict: this.makeConflictHandler(),
       onStatusChange: (event) => {
+        // Reset the conflict handler's apply-to-all memory at the start of every
+        // sync phase. The user's "apply to all" choice is scoped to a single round,
+        // not "forever" — without this, a stale choice from yesterday's sync would
+        // silently steamroll today's conflicts.
+        if (event.state === 'syncing') {
+          this.vaultConflictHandler?.reset();
+        }
+
         this.status =
           event.state === 'idle' ? 'idle' : event.state === 'syncing' ? 'syncing' : 'error';
 
@@ -487,23 +501,26 @@ export default class SilentStoneSyncPlugin extends Plugin {
   /**
    * Build the conflict handler the engine consults when a real divergence is detected.
    * Honors `settings.conflictStrategy`:
-   *   - `keep-local` / `keep-server` / `keep-both` → return directly.
-   *   - `ask` → fall back to `keep-server` until LOC-12 lands the modal. A Notice
-   *     surfaces the fallback so the user is aware their `'ask'` preference is being
-   *     deferred (rather than silently picking server).
+   *   - `keep-local` / `keep-server` / `keep-both` → return directly (no UI).
+   *   - `ask` → open ConflictModal per file. The factory remembers an "apply to all"
+   *     choice across the sync round; `onStatusChange` resets that memory on every
+   *     `'syncing'` event so the choice never leaks into a future round.
    */
   private makeConflictHandler(): ConflictHandler {
-    return (info): ConflictResolution => {
-      const strategy = this.settings.conflictStrategy;
-      if (strategy === 'keep-local' || strategy === 'keep-server' || strategy === 'keep-both') {
-        return strategy;
-      }
-      new Notice(
-        `Conflict on ${info.path}: keeping server copy (interactive prompt coming in a future update).`,
-        6000,
-      );
-      return 'keep-server';
-    };
+    this.vaultConflictHandler = createConflictHandler({
+      getStrategy: () => this.settings.conflictStrategy,
+      openConflictModal: async (info) => {
+        const stat = await this.app.vault.adapter.stat(info.path);
+        const localModifiedAt = stat?.mtime ?? 0;
+        return new Promise<ConflictModalChoice | null>((resolve) => {
+          const modal = new ConflictModal(this.app, info, localModifiedAt, {
+            onResolve: (c) => resolve(c),
+          });
+          modal.open();
+        });
+      },
+    });
+    return this.vaultConflictHandler.handler;
   }
 
   lockVault(): void {

--- a/src/sync/__tests__/conflict-handler.test.ts
+++ b/src/sync/__tests__/conflict-handler.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createConflictHandler } from '../conflict-handler';
+import type { ConflictInfo } from '../engine';
+import type { ConflictModalChoice } from '../../ui/sync-modal';
+
+function makeInfo(path: string): ConflictInfo {
+  return {
+    path,
+    localHash: 'a',
+    serverHash: 'b',
+    lastKnownHash: 'c',
+    localContent: new ArrayBuffer(0),
+    serverContent: new ArrayBuffer(0),
+    serverModifiedAt: 0,
+  };
+}
+
+type StrategyValue = 'ask' | 'keep-local' | 'keep-server' | 'keep-both';
+
+function buildHandler(opts: {
+  strategy: StrategyValue;
+  modalChoices?: (ConflictModalChoice | null)[];
+}) {
+  const queue = [...(opts.modalChoices ?? [])];
+  const openConflictModal = vi.fn().mockImplementation(async () => {
+    if (queue.length === 0) throw new Error('test ran out of mocked modal choices');
+    return queue.shift()!;
+  });
+  const getStrategy = vi.fn(() => opts.strategy);
+  const factory = createConflictHandler({ getStrategy, openConflictModal });
+  return { ...factory, openConflictModal, getStrategy };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Strategy short-circuit ─────────────────────────
+describe('createConflictHandler — non-ask strategies', () => {
+  it('returns "keep-local" without opening the modal', async () => {
+    const h = buildHandler({ strategy: 'keep-local' });
+    const result = await h.handler(makeInfo('a.md'));
+    expect(result).toBe('keep-local');
+    expect(h.openConflictModal).not.toHaveBeenCalled();
+  });
+
+  it('returns "keep-server" without opening the modal', async () => {
+    const h = buildHandler({ strategy: 'keep-server' });
+    const result = await h.handler(makeInfo('a.md'));
+    expect(result).toBe('keep-server');
+    expect(h.openConflictModal).not.toHaveBeenCalled();
+  });
+
+  it('returns "keep-both" without opening the modal', async () => {
+    const h = buildHandler({ strategy: 'keep-both' });
+    const result = await h.handler(makeInfo('a.md'));
+    expect(result).toBe('keep-both');
+    expect(h.openConflictModal).not.toHaveBeenCalled();
+  });
+});
+
+// ── Ask: per-file modal flow ───────────────────────
+describe('createConflictHandler — ask, single file', () => {
+  it('opens the modal and returns the user-picked resolution', async () => {
+    const h = buildHandler({
+      strategy: 'ask',
+      modalChoices: [{ resolution: 'keep-server', applyToAll: false }],
+    });
+    const result = await h.handler(makeInfo('a.md'));
+    expect(h.openConflictModal).toHaveBeenCalledOnce();
+    expect(result).toBe('keep-server');
+  });
+
+  it('treats a null modal choice (dismissed) as keep-local (safe default)', async () => {
+    const h = buildHandler({ strategy: 'ask', modalChoices: [null] });
+    const result = await h.handler(makeInfo('a.md'));
+    expect(result).toBe('keep-local');
+  });
+});
+
+// ── Ask: batch / apply-to-all ──────────────────────
+describe('createConflictHandler — ask, batch with apply-to-all', () => {
+  it('opens modal once when first choice is applyToAll, then short-circuits', async () => {
+    const h = buildHandler({
+      strategy: 'ask',
+      modalChoices: [{ resolution: 'keep-server', applyToAll: true }],
+    });
+
+    const a = await h.handler(makeInfo('a.md'));
+    const b = await h.handler(makeInfo('b.md'));
+    const c = await h.handler(makeInfo('c.md'));
+
+    expect(a).toBe('keep-server');
+    expect(b).toBe('keep-server');
+    expect(c).toBe('keep-server');
+    expect(h.openConflictModal).toHaveBeenCalledOnce();
+  });
+
+  it('opens modal per-file when applyToAll stays false', async () => {
+    const h = buildHandler({
+      strategy: 'ask',
+      modalChoices: [
+        { resolution: 'keep-local', applyToAll: false },
+        { resolution: 'keep-server', applyToAll: false },
+        { resolution: 'keep-both', applyToAll: false },
+      ],
+    });
+
+    const a = await h.handler(makeInfo('a.md'));
+    const b = await h.handler(makeInfo('b.md'));
+    const c = await h.handler(makeInfo('c.md'));
+
+    expect(a).toBe('keep-local');
+    expect(b).toBe('keep-server');
+    expect(c).toBe('keep-both');
+    expect(h.openConflictModal).toHaveBeenCalledTimes(3);
+  });
+
+  it('reset() clears the apply-to-all memory so the next call opens the modal again', async () => {
+    const h = buildHandler({
+      strategy: 'ask',
+      modalChoices: [
+        { resolution: 'keep-server', applyToAll: true },
+        { resolution: 'keep-local', applyToAll: false },
+      ],
+    });
+
+    await h.handler(makeInfo('a.md')); // opens modal, sets appliedToAll
+    await h.handler(makeInfo('b.md')); // short-circuit
+    h.reset();
+    const c = await h.handler(makeInfo('c.md')); // opens modal again
+
+    expect(c).toBe('keep-local');
+    expect(h.openConflictModal).toHaveBeenCalledTimes(2);
+  });
+
+  it('honors a strategy switch between calls (non-ask wins, modal not opened)', async () => {
+    const choices: (ConflictModalChoice | null)[] = [
+      { resolution: 'keep-server', applyToAll: false },
+    ];
+    const openConflictModal = vi.fn().mockImplementation(async () => choices.shift());
+    let strategy: StrategyValue = 'ask';
+    const getStrategy = () => strategy;
+    const { handler } = createConflictHandler({ getStrategy, openConflictModal });
+
+    expect(await handler(makeInfo('a.md'))).toBe('keep-server');
+    strategy = 'keep-local';
+    expect(await handler(makeInfo('b.md'))).toBe('keep-local');
+    expect(openConflictModal).toHaveBeenCalledOnce();
+  });
+});

--- a/src/sync/conflict-handler.ts
+++ b/src/sync/conflict-handler.ts
@@ -1,0 +1,57 @@
+import type { ConflictHandler, ConflictInfo, ConflictResolution } from './engine';
+import type { ConflictModalChoice } from '../ui/sync-modal';
+
+export interface ConflictHandlerDeps {
+  /** Read the user's chosen strategy at decision time, not at construction. */
+  getStrategy: () => 'ask' | 'keep-local' | 'keep-server' | 'keep-both';
+  /**
+   * Open the conflict modal for one file and resolve with the user's choice.
+   * `null` means the modal was dismissed without a pick — the factory
+   * defaults that to `keep-local` (preserve the user's local copy).
+   */
+  openConflictModal: (info: ConflictInfo) => Promise<ConflictModalChoice | null>;
+}
+
+export interface ConflictHandlerWithReset {
+  handler: ConflictHandler;
+  /**
+   * Clear the apply-to-all memory so the next conflict opens the modal again.
+   * Call between sync rounds — the user's "apply to all" choice should not
+   * leak into a future round they didn't consent to.
+   */
+  reset: () => void;
+}
+
+/**
+ * Build the engine's conflict handler from injectable deps. Pure factory:
+ * no Obsidian, no plugin types, easy to test.
+ *
+ * Behavior:
+ * - Strategy `keep-local`/`keep-server`/`keep-both` → return that, never opens modal.
+ * - Strategy `ask` → open modal per file. If the user picked "apply to all",
+ *   remember the resolution and return it for every subsequent call until reset().
+ * - Modal dismissed (null) → `keep-local` (safe default, never destroys local work).
+ */
+export function createConflictHandler(deps: ConflictHandlerDeps): ConflictHandlerWithReset {
+  let appliedToAll: ConflictResolution | null = null;
+
+  const handler: ConflictHandler = async (info) => {
+    const strategy = deps.getStrategy();
+    if (strategy !== 'ask') return strategy;
+
+    if (appliedToAll) return appliedToAll;
+
+    const choice = await deps.openConflictModal(info);
+    if (choice === null) return 'keep-local';
+
+    if (choice.applyToAll) appliedToAll = choice.resolution;
+    return choice.resolution;
+  };
+
+  return {
+    handler,
+    reset: () => {
+      appliedToAll = null;
+    },
+  };
+}

--- a/src/ui/__tests__/sync-modal.test.ts
+++ b/src/ui/__tests__/sync-modal.test.ts
@@ -1,0 +1,335 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mock `obsidian` ────────────────────────────────
+// ConflictModal extends Obsidian's Modal and uses Setting builders for its
+// button row + apply-to-all toggle. We hand-roll the same minimal widget
+// surface unlock-modal.test uses, plus addToggle (the conflict modal needs
+// a checkbox, unlock didn't).
+const { MockModal, MockSetting, lastSettings } = vi.hoisted(() => {
+  type FakeButtonEl = { disabled: boolean; textContent: string };
+
+  type FakeEl = {
+    tagName: string;
+    textContent: string;
+    children: FakeEl[];
+    cls: string[];
+    style: Record<string, string>;
+    attrs: Record<string, string>;
+    createEl: (
+      tag: string,
+      opts?: { text?: string; cls?: string; attr?: Record<string, string> },
+    ) => FakeEl;
+    setText: (t: string) => void;
+    empty: () => void;
+  };
+
+  type ButtonHandler = {
+    label: string;
+    buttonEl: FakeButtonEl;
+    onClick?: () => void | Promise<void>;
+    isCta: boolean;
+    isWarning: boolean;
+  };
+
+  type ToggleHandler = {
+    value: boolean;
+    onChange?: (v: boolean) => void;
+  };
+
+  type Handlers = {
+    name: string;
+    desc: string;
+    buttonHandlers: ButtonHandler[];
+    toggleHandlers: ToggleHandler[];
+  };
+
+  const allSettings: Handlers[] = [];
+
+  function createFakeEl(tag: string): FakeEl {
+    const el: FakeEl = {
+      tagName: tag.toUpperCase(),
+      textContent: '',
+      children: [],
+      cls: [],
+      style: {},
+      attrs: {},
+      createEl: (t, opts) => {
+        const child = createFakeEl(t);
+        if (opts?.text) child.textContent = opts.text;
+        if (opts?.cls) {
+          for (const c of opts.cls.split(/\s+/)) child.cls.push(c);
+        }
+        if (opts?.attr) {
+          for (const [k, v] of Object.entries(opts.attr)) child.attrs[k] = v;
+        }
+        el.children.push(child);
+        return child;
+      },
+      setText: (t) => {
+        el.textContent = t;
+      },
+      empty: () => {
+        el.children = [];
+        el.textContent = '';
+      },
+    };
+    return el;
+  }
+
+  class MockModal {
+    app: unknown;
+    contentEl: FakeEl;
+    close: ReturnType<typeof vi.fn>;
+
+    constructor(app: unknown) {
+      this.app = app;
+      this.contentEl = createFakeEl('div');
+      this.close = vi.fn();
+    }
+
+    open(): void {
+      (this as unknown as { onOpen?: () => void }).onOpen?.();
+    }
+  }
+
+  class MockSetting {
+    private handlers: Handlers;
+
+    constructor(_parent: unknown) {
+      this.handlers = {
+        name: '',
+        desc: '',
+        buttonHandlers: [],
+        toggleHandlers: [],
+      };
+      allSettings.push(this.handlers);
+    }
+
+    setName(name: string): this {
+      this.handlers.name = name;
+      return this;
+    }
+
+    setDesc(desc: string): this {
+      this.handlers.desc = desc;
+      return this;
+    }
+
+    addButton(cb: (b: unknown) => void): this {
+      const buttonEl: FakeButtonEl = { disabled: false, textContent: '' };
+      const captured: ButtonHandler = {
+        label: '',
+        buttonEl,
+        isCta: false,
+        isWarning: false,
+      };
+      const api = {
+        setButtonText: (t: string) => {
+          captured.label = t;
+          buttonEl.textContent = t;
+          return api;
+        },
+        setCta: () => {
+          captured.isCta = true;
+          return api;
+        },
+        setWarning: () => {
+          captured.isWarning = true;
+          return api;
+        },
+        onClick: (fn: () => void | Promise<void>) => {
+          captured.onClick = fn;
+          return api;
+        },
+        buttonEl,
+      };
+      cb(api);
+      this.handlers.buttonHandlers.push(captured);
+      return this;
+    }
+
+    addToggle(cb: (t: unknown) => void): this {
+      const captured: ToggleHandler = { value: false };
+      const api = {
+        setValue: (v: boolean) => {
+          captured.value = v;
+          return api;
+        },
+        onChange: (fn: (v: boolean) => void) => {
+          captured.onChange = fn;
+          return api;
+        },
+      };
+      cb(api);
+      this.handlers.toggleHandlers.push(captured);
+      return this;
+    }
+  }
+
+  function lastSettings(): Handlers[] {
+    return allSettings;
+  }
+
+  return { MockModal, MockSetting, lastSettings };
+});
+
+vi.mock('obsidian', () => ({
+  App: class {},
+  Modal: MockModal,
+  Setting: MockSetting,
+}));
+
+import { ConflictModal, type ConflictModalChoice } from '../sync-modal';
+import type { ConflictInfo } from '../../sync/engine';
+
+// ── Fixtures ───────────────────────────────────────
+function makeConflictInfo(overrides: Partial<ConflictInfo> = {}): ConflictInfo {
+  const enc = new TextEncoder();
+  return {
+    path: 'notes/foo.md',
+    localHash: 'aaaaaaaaaaaa',
+    serverHash: 'bbbbbbbbbbbb',
+    lastKnownHash: 'cccccccccccc',
+    localContent: enc.encode('local body').buffer,
+    serverContent: enc.encode('server body').buffer,
+    serverModifiedAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+type Choices = (ConflictModalChoice | null)[];
+
+function openModal(
+  info: ConflictInfo = makeConflictInfo(),
+  localModifiedAt = 1_700_000_050_000,
+): { modal: ConflictModal; choices: Choices } {
+  const choices: Choices = [];
+  const modal = new ConflictModal({} as never, info, localModifiedAt, {
+    onResolve: (c) => choices.push(c),
+  });
+  (modal as unknown as { open: () => void }).open();
+  return { modal, choices };
+}
+
+type TreeNode = { textContent: string; children: TreeNode[] };
+
+function findByText(el: unknown, needle: string): boolean {
+  const node = el as TreeNode;
+  if ((node.textContent ?? '').includes(needle)) return true;
+  for (const c of node.children ?? []) {
+    if (findByText(c, needle)) return true;
+  }
+  return false;
+}
+
+function allButtons() {
+  return lastSettings().flatMap((s) => s.buttonHandlers);
+}
+
+function clickButton(label: string): void {
+  const btn = allButtons().find((b) => b.label === label);
+  if (!btn) {
+    const labels = allButtons().map((b) => b.label).join(', ');
+    throw new Error(`No button labeled "${label}". Found: [${labels}]`);
+  }
+  void btn.onClick?.();
+}
+
+function setApplyToAll(value: boolean): void {
+  const toggle = lastSettings().flatMap((s) => s.toggleHandlers)[0];
+  if (!toggle) throw new Error('No apply-to-all toggle rendered');
+  toggle.value = value;
+  toggle.onChange?.(value);
+}
+
+beforeEach(() => {
+  const all = lastSettings();
+  all.length = 0;
+  vi.clearAllMocks();
+});
+
+// ── Render ─────────────────────────────────────────
+describe('ConflictModal — render', () => {
+  it('shows the file path in the modal body', () => {
+    const { modal } = openModal(makeConflictInfo({ path: 'notes/important.md' }));
+    expect(findByText(modal.contentEl, 'notes/important.md')).toBe(true);
+  });
+
+  it('shows server mod time as a human-readable ISO timestamp', () => {
+    const { modal } = openModal(makeConflictInfo({ serverModifiedAt: 1_700_000_000_000 }));
+    expect(findByText(modal.contentEl, new Date(1_700_000_000_000).toISOString())).toBe(true);
+  });
+
+  it('shows local mod time as a human-readable ISO timestamp', () => {
+    const { modal } = openModal(makeConflictInfo(), 1_700_000_050_000);
+    expect(findByText(modal.contentEl, new Date(1_700_000_050_000).toISOString())).toBe(true);
+  });
+
+  it('renders all four action buttons (Keep Local, Take Server, Keep Both, Skip)', () => {
+    openModal();
+    const labels = allButtons().map((b) => b.label);
+    expect(labels).toEqual(expect.arrayContaining(['Keep Local', 'Take Server', 'Keep Both', 'Skip']));
+  });
+
+  it('renders an apply-to-all toggle, defaulted off', () => {
+    openModal();
+    const toggle = lastSettings().flatMap((s) => s.toggleHandlers)[0];
+    expect(toggle).toBeDefined();
+    expect(toggle.value).toBe(false);
+  });
+});
+
+// ── Actions ────────────────────────────────────────
+describe('ConflictModal — actions', () => {
+  it('Keep Local resolves with { resolution: "keep-local", applyToAll: false } and closes modal', () => {
+    const { modal, choices } = openModal();
+    clickButton('Keep Local');
+    expect(choices).toEqual([{ resolution: 'keep-local', applyToAll: false }]);
+    expect(modal.close).toHaveBeenCalledOnce();
+  });
+
+  it('Take Server resolves with keep-server', () => {
+    const { modal, choices } = openModal();
+    clickButton('Take Server');
+    expect(choices).toEqual([{ resolution: 'keep-server', applyToAll: false }]);
+    expect(modal.close).toHaveBeenCalledOnce();
+  });
+
+  it('Keep Both resolves with keep-both', () => {
+    const { modal, choices } = openModal();
+    clickButton('Keep Both');
+    expect(choices).toEqual([{ resolution: 'keep-both', applyToAll: false }]);
+    expect(modal.close).toHaveBeenCalledOnce();
+  });
+
+  it('Skip resolves with keep-local (safe default — preserves local copy untouched)', () => {
+    const { modal, choices } = openModal();
+    clickButton('Skip');
+    expect(choices).toEqual([{ resolution: 'keep-local', applyToAll: false }]);
+    expect(modal.close).toHaveBeenCalledOnce();
+  });
+});
+
+// ── Apply-to-all batch behavior ────────────────────
+describe('ConflictModal — apply to all', () => {
+  it('toggling apply-to-all on then clicking Take Server returns applyToAll=true', () => {
+    const { choices } = openModal();
+    setApplyToAll(true);
+    clickButton('Take Server');
+    expect(choices).toEqual([{ resolution: 'keep-server', applyToAll: true }]);
+  });
+
+  it('toggling apply-to-all on then clicking Keep Local returns applyToAll=true', () => {
+    const { choices } = openModal();
+    setApplyToAll(true);
+    clickButton('Keep Local');
+    expect(choices).toEqual([{ resolution: 'keep-local', applyToAll: true }]);
+  });
+
+  it('Skip ignores apply-to-all (deferral is per-file by definition)', () => {
+    const { choices } = openModal();
+    setApplyToAll(true);
+    clickButton('Skip');
+    expect(choices).toEqual([{ resolution: 'keep-local', applyToAll: false }]);
+  });
+});

--- a/src/ui/sync-modal.ts
+++ b/src/ui/sync-modal.ts
@@ -1,14 +1,110 @@
-/**
- * Sync modal — manual sync trigger and conflict resolution UI.
- *
- * TODO: Implement
- * - SyncConflictModal extends Modal
- * - Shows: file path, local mod time, server mod time
- * - Actions: Keep Local, Take Server, Keep Both
- * - Preview of differences (if files are small enough)
- * - Batch resolution for multiple conflicts
- */
+import { App, Modal, Setting } from 'obsidian';
+import type { ConflictInfo, ConflictResolution } from '../sync/engine';
 
-export class SyncModal {
-  // Placeholder — will extend Obsidian's Modal class
+export interface ConflictModalChoice {
+  resolution: ConflictResolution;
+  applyToAll: boolean;
+}
+
+export interface ConflictModalOpts {
+  /**
+   * Called exactly once: when the user picks an action OR closes the modal
+   * without choosing. `null` means "no decision" — the handler factory should
+   * default that to the safe choice (preserve local).
+   */
+  onResolve: (choice: ConflictModalChoice | null) => void;
+}
+
+/**
+ * Conflict resolution modal — opened when the engine's divergence detector
+ * finds that both sides changed since the last sync AND the user's chosen
+ * strategy is `'ask'`. Resolves with the user's per-file choice and an
+ * `applyToAll` flag the handler factory uses to short-circuit the rest of
+ * this sync round.
+ */
+export class ConflictModal extends Modal {
+  private readonly info: ConflictInfo;
+  private readonly localModifiedAt: number;
+  private readonly opts: ConflictModalOpts;
+  private applyToAll = false;
+  private resolved = false;
+
+  constructor(app: App, info: ConflictInfo, localModifiedAt: number, opts: ConflictModalOpts) {
+    super(app);
+    this.info = info;
+    this.localModifiedAt = localModifiedAt;
+    this.opts = opts;
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+
+    contentEl.createEl('h2', { text: 'Resolve sync conflict' });
+    contentEl.createEl('p', {
+      text: this.info.path,
+      cls: 'setting-item-description',
+    });
+    contentEl.createEl('p', {
+      text: `Local modified: ${new Date(this.localModifiedAt).toISOString()}`,
+      cls: 'setting-item-description',
+    });
+    contentEl.createEl('p', {
+      text: `Server modified: ${new Date(this.info.serverModifiedAt).toISOString()}`,
+      cls: 'setting-item-description',
+    });
+
+    new Setting(contentEl)
+      .setName('Apply this choice to all remaining conflicts')
+      .setDesc('Skip applies per-file regardless.')
+      .addToggle((t) =>
+        t.setValue(false).onChange((v) => {
+          this.applyToAll = v;
+        }),
+      );
+
+    new Setting(contentEl)
+      .addButton((btn) =>
+        btn
+          .setButtonText('Keep Local')
+          .setCta()
+          .onClick(() => this.pick('keep-local')),
+      )
+      .addButton((btn) =>
+        btn.setButtonText('Take Server').onClick(() => this.pick('keep-server')),
+      )
+      .addButton((btn) =>
+        btn.setButtonText('Keep Both').onClick(() => this.pick('keep-both')),
+      )
+      .addButton((btn) =>
+        btn.setButtonText('Skip').onClick(() => this.skip()),
+      );
+  }
+
+  onClose(): void {
+    // If the user dismissed the modal (Esc, click outside) without picking,
+    // hand back null so the handler factory falls through to its safe default.
+    // Otherwise the engine's await would hang forever.
+    if (!this.resolved) {
+      this.resolved = true;
+      this.opts.onResolve(null);
+    }
+    this.contentEl.empty();
+  }
+
+  private pick(resolution: ConflictResolution): void {
+    if (this.resolved) return;
+    this.resolved = true;
+    this.opts.onResolve({ resolution, applyToAll: this.applyToAll });
+    this.close();
+  }
+
+  private skip(): void {
+    if (this.resolved) return;
+    this.resolved = true;
+    // Skip is a per-file deferral. Even if "apply to all" is checked, we
+    // ignore it — the user is explicitly saying "don't decide globally."
+    this.opts.onResolve({ resolution: 'keep-local', applyToAll: false });
+    this.close();
+  }
 }


### PR DESCRIPTION
Replaces the silent keep-server fallback when conflictStrategy is 'ask' — users now get a per-file modal with Keep Local / Take Server / Keep Both / Skip plus apply-to-all batch resolution.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
