### PR TITLE
chore(claude): enable silent-stone org plugin (LOC-55)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,5 +11,11 @@
         ]
       }
     ]
-  }
+  },
+  "extraKnownMarketplaces": {
+    "silent-stone-org": {
+      "source": { "source": "github", "repo": "josemoreno801-netizen/silent-stone-claude" }
+    }
+  },
+  "enabledPlugins": { "silent-stone@silent-stone-org": true }
 }

--- a/.claude/ss-config.json
+++ b/.claude/ss-config.json
@@ -1,0 +1,1 @@
+{ "projectId": "90f7de75-e92b-4287-84f0-0d5b703d9730", "repoRole": "field" }


### PR DESCRIPTION
## Summary

Per-repo enablement of the org Claude Code plugin (spec PR #4, now on `main` in silent-stone-org). Two **additive** changes:

- `.claude/settings.json` — added `extraKnownMarketplaces.silent-stone-org` + `enabledPlugins."silent-stone@silent-stone-org": true`. Existing vitest `PostToolUse` hook **preserved unchanged** (additive-only diff verified).
- `.claude/ss-config.json` — new: `{ projectId: 90f7de75…, repoRole: field }` (Tier-2 binding, spec Section 3).

Authority: `silent-stone-org/docs/superpowers/specs/2026-05-15-org-claude-plugin-marketplace-design.md` Section 6. Project UUID reconfirmed against live Linear.

> This repo is **public**. The committed config references the private marketplace repo by name only — no secret content is exposed (GitHub gates private-repo access). Spec applies Section 6 uniformly to all 4 repos.

**Scope:** enablement only. No cutover (gated on spec Gate 3 + live load-verify, downstream).

LOC-55.

## Test plan

- [ ] Live session: `/silent-stone:status` resolves without manual marketplace add (spec Gate 1 — downstream)
- [ ] vitest PostToolUse hook still fires on `.ts(x)` edits
- [ ] `ss-config.json` resolves obsidian → project 90f7de75… via plugin `doctrine.json` (spec Gate 2 — downstream)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

### `.claude/settings.json`
Added configuration for the silent-stone Claude Code plugin from the org marketplace:
- Registered `silent-stone-org` as a known marketplace source, pointing to the `josemoreno801-netizen/silent-stone-claude` GitHub repository
- Enabled the `silent-stone@silent-stone-org` plugin
- Existing `PostToolUse` vitest hook for TypeScript file testing preserved unchanged

### `.claude/ss-config.json` (new file)
Created configuration file establishing the repository binding to the silent-stone project:
- `projectId`: `90f7de75-e92b-4287-84f0-0d5b703d9730`
- `repoRole`: `field` (Tier-2 binding)

## Context

This PR implements per-repository enablement of the org-provided Claude Code plugin as specified in silent-stone-org's plugin marketplace design documentation (Section 6). The changes are additive only with no cutover performance impact. The project UUID has been verified against the live Linear project tracking system. Configuration files reference the private marketplace repository by name only and contain no embedded secrets.

## Verification Gates

The enablement is gated for cutover completion pending downstream:
1. Live session verification that `/silent-stone:status` resolves without manual marketplace addition
2. Confirmation that vitest PostToolUse hook continues to fire on `.ts(x)` file edits
3. Project resolution validation via the plugin's `doctrine.json` configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josemoreno801-netizen/silent-stone-obsidian/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->